### PR TITLE
fix(ci): workflow path 跟随 i18n URL 段化（修 sync-uuid 失败 + IndexNow 双语推送）

### DIFF
--- a/.github/workflows/content-check.yml
+++ b/.github/workflows/content-check.yml
@@ -10,7 +10,8 @@ on:
       - "**/*.md"
       - "**/*.mdx"
       - "source.config.ts"
-      - "app/docs/**"
+      # 2026-05 i18n URL 段化：mdx 内容从 app/docs/ 迁到 content/docs/
+      - "content/docs/**"
       - "data/**"
       - "tests/**"
       - "lib/source.ts"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,6 +83,15 @@ jobs:
           # 文件命名约定（fumadocs dot parser）：
           #   xxx.mdx        → 默认 (zh) 原文，slug = xxx
           #   xxx.en.mdx     → en 翻译，slug = xxx（去 .en 后缀提 base slug）
+          #
+          # 例外：career/interview-prep/leetcode/ 下含中文的文件名会被
+          # lib/source.ts 的 transformer 拼音化（convertSlugToPinyin），
+          # 实际路由的最后一段是拼音 slug 而不是中文 stem。这里复用
+          # generated/leetcode-slug-map.json （prebuild 时由
+          # scripts/generate-leetcode-slug-map.mts 与 source.ts 同算法生成）
+          # 把中文 stem 映射到拼音 slug，否则推送的 URL 会 404。
+          LEETCODE_PREFIX="career/interview-prep/leetcode/"
+          SLUG_MAP_FILE="generated/leetcode-slug-map.json"
           URLS=()
 
           while IFS= read -r f; do
@@ -94,6 +103,17 @@ jobs:
               slug="${slug%.zh}"
               # index.mdx 对应目录本身的 URL（fumadocs 约定）
               slug="${slug%/index}"
+
+              # leetcode 中文 stem → 拼音 slug 映射（与 source.ts transformer 一致）
+              if [[ "$slug" == "$LEETCODE_PREFIX"* && -f "$SLUG_MAP_FILE" ]]; then
+                stem="${slug##*/}"
+                dir="${slug%/*}"
+                mapped="$(jq -r --arg k "$stem" '.[$k] // empty' "$SLUG_MAP_FILE")"
+                if [ -n "$mapped" ]; then
+                  slug="$dir/$mapped"
+                fi
+              fi
+
               URLS+=("$SITE_ORIGIN/zh/docs/$slug")
               URLS+=("$SITE_ORIGIN/en/docs/$slug")
             fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
         run: node scripts/check-pnpm-version.mjs
 
       - run: pnpm install --frozen-lockfile
-      
+
       # Verify lockfile wasn't modified by install
       - name: Check lockfile consistency
         run: |
@@ -75,31 +75,36 @@ jobs:
 
           git fetch --depth=2 origin ${{ github.ref }} || true
           CHANGED="$(git diff --name-only HEAD~1 HEAD || true)"
-          CHANGED_DOCS="$(echo "$CHANGED" | grep -E '^(app/docs/|content/docs/).*\.(mdx?|tsx?)$' || true)"
+          CHANGED_DOCS="$(echo "$CHANGED" | grep -E '^content/docs/.*\.(md|mdx)$' || true)"
 
+          # i18n URL 段化（2026-05）后所有 docs URL 都带 /<locale>/ 前缀。
+          # 每篇文档对外有 /zh/docs/<slug> 和 /en/docs/<slug> 两个独立 URL，
+          # 任意文件变更都推送两条让 IndexNow 同时刷新两种语言版本。
+          # 文件命名约定（fumadocs dot parser）：
+          #   xxx.mdx        → 默认 (zh) 原文，slug = xxx
+          #   xxx.en.mdx     → en 翻译，slug = xxx（去 .en 后缀提 base slug）
           URLS=()
-
-          while IFS= read -r f; do
-            [ -z "$f" ] && continue
-            if [[ "$f" =~ ^app/docs/(.*)/page\.(mdx|md|tsx|ts|jsx|js)$ ]]; then
-              slug="${BASH_REMATCH[1]}"
-              URLS+=("$SITE_ORIGIN/docs/$slug")
-            fi
-          done <<< "$CHANGED_DOCS"
 
           while IFS= read -r f; do
             [ -z "$f" ] && continue
             if [[ "$f" =~ ^content/docs/(.*)\.(md|mdx)$ ]]; then
               slug="${BASH_REMATCH[1]}"
+              # 剥离 locale 后缀（.en / .zh），拿到 canonical base slug
+              slug="${slug%.en}"
+              slug="${slug%.zh}"
+              # index.mdx 对应目录本身的 URL（fumadocs 约定）
               slug="${slug%/index}"
-              URLS+=("$SITE_ORIGIN/docs/$slug")
+              URLS+=("$SITE_ORIGIN/zh/docs/$slug")
+              URLS+=("$SITE_ORIGIN/en/docs/$slug")
             fi
           done <<< "$CHANGED_DOCS"
 
           mapfile -t URLS < <(printf "%s\n" "${URLS[@]}" | awk 'NF' | sort -u)
 
           if [ "${#URLS[@]}" -eq 0 ]; then
-            URLS=("$SITE_ORIGIN/")
+            # 没有 docs 改动时（例如改 README / 配置等）仍提交首页让 Bing/Yandex
+            # 知道站点活跃。i18n 段化后首页有两个 URL，分别推送。
+            URLS=("$SITE_ORIGIN/zh" "$SITE_ORIGIN/en")
           fi
 
           echo "✅ Submitting URLs to IndexNow:"

--- a/.github/workflows/sync-uuid.yml
+++ b/.github/workflows/sync-uuid.yml
@@ -22,7 +22,8 @@ on:
       - main
       - feat/contributor
     paths:
-      - "app/docs/**"
+      # 2026-05 i18n URL 段化：mdx 内容从 app/docs/ 迁到 content/docs/
+      - "content/docs/**"
       - "scripts/uuid.mjs"
       - "scripts/backfill-contributors.mjs"
       - "package.json"
@@ -146,10 +147,10 @@ jobs:
             # 只 commit MDX frontmatter 改动 + 生成的 JSON，不包含任何其他脏文件。
             # [skip ci] 防止自提交再次触发本 workflow 死循环。
             # ============================================================
-            if ! git diff --quiet -- 'app/docs/**/*.md' 'app/docs/**/*.mdx' generated/doc-contributors.json; then
+            if ! git diff --quiet -- 'content/docs/**/*.md' 'content/docs/**/*.mdx' generated/doc-contributors.json; then
               git config user.name "github-actions[bot]"
               git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-              git add 'app/docs/**/*.md' 'app/docs/**/*.mdx' generated/doc-contributors.json
+              git add 'content/docs/**/*.md' 'content/docs/**/*.mdx' generated/doc-contributors.json
               git commit -m "chore(docs): sync doc metadata [skip ci]"
               git push origin "$BRANCH"
             else


### PR DESCRIPTION
## 问题

i18n PR #330 merge 后两个 CI 问题：

### 1. \`sync-uuid\` workflow 在 main 上 fail（hard error）

[Run #25441855788](https://github.com/InvolutionHell/involutionhell/actions/runs/25441855788) 失败：

\`\`\`
fatal: pathspec 'app/docs/**/*.md' did not match any files
2026/05/06 14:38:15 Process exited with status 128
\`\`\`

backfill 脚本本身已经成功生成 153 条 contributor entries（都是 content/docs/...
路径，证明改造对了），但最后这一步：

\`\`\`yaml
git add 'app/docs/**/*.md' 'app/docs/**/*.mdx' generated/doc-contributors.json
\`\`\`

\`app/docs/\` 已经搬到 \`content/docs/\` 整个删除了，pathspec 不匹配 → git 退
出 128 → workflow fail。**贡献者署名生命线挂了**。

### 2. \`deploy.yml\` 的 IndexNow 推送 URL 没加 locale 前缀

i18n 段化后 docs URL 都是 \`/zh/docs/...\` 或 \`/en/docs/...\`。当前推送的是
\`/docs/...\`（不带 locale），Bing/Yandex 收到后会：
- 命中 next-intl 308 redirect，IndexNow 当作"老 URL"处理
- 新的 \`/zh/docs/...\` \`/en/docs/...\` 永远不会被主动通知

## 修

### \`sync-uuid.yml\`
- \`paths\` trigger \`app/docs/**\` → \`content/docs/**\`
- 自动 commit 阶段 \`git diff / git add\` 路径同步改

### \`content-check.yml\`
- \`paths\` trigger 同步改

### \`deploy.yml\` (IndexNow)
- 删掉旧 \`app/docs/(.*)/page.tsx\` 提取分支（不再有 page.tsx-as-content 的形态）
- \`content/docs/(.*).mdx\` 提 base slug 时剥离 \`.en\` / \`.zh\` 后缀，拿
  canonical slug
- 每篇文档推送 **zh + en 两条 URL**（i18n 段化后这是两个独立 URL）
- fallback 首页 URL 也改成 \`/zh\` + \`/en\` 双语

## 影响

- \`sync-uuid\` 修好后下次跑会自动 commit 新生成的 \`generated/doc-contributors.json\`
  （含 153 条 i18n 改造后的最新署名快照）。本 PR 故意**不**带这个 JSON
  改动，留给 workflow 自己 commit，避免人工出错
- IndexNow 修好后下次任何 docs commit 都会双语通知 Bing/Yandex，加速新
  URL 索引

## Test plan

- [ ] PR merge → \`sync-uuid\` workflow 不再 fail，自动 commit doc-contributors.json
- [ ] \`deploy.yml\` IndexNow 步骤推送的 URL 列表都带 \`/zh\` 或 \`/en\` 前缀
- [ ] 一周内 Bing Webmaster Tools 看到新 URL 收录上升