### PR TITLE
perf(homepage): 首页 SSG 化，剩 25% Vercel CPU 归零

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -6,7 +6,6 @@ import { Hero } from "@/app/components/Hero";
 import { DispatchNetwork } from "@/app/components/DispatchNetwork";
 import { Footer } from "@/app/components/Footer";
 import { FloatWindow } from "@/app/components/float-window/FloatWindow";
-import { fetchHomepageEvents } from "@/lib/events-fetch";
 import { routing } from "@/i18n/routing";
 
 interface Props {
@@ -16,22 +15,21 @@ interface Props {
 /**
  * 站点首页 (/[locale])。
  *
- * i18n 改造前是 RSC + cookies()，整页 dynamic。改造后通过 setRequestLocale
- * 启用 SSG —— 但这页 await fetchHomepageEvents 仍然是 server fetch，会把
- * 整页钉成 dynamic（fetch 命中 cache 也算访问态）。
+ * SSG 化（i18n 改造收尾，2026-05）：
+ *   原版 await fetchHomepageEvents() server fetch backend，把首页钉成
+ *   ƒ Dynamic。改造让 FloatWindow / ActivityTicker 各自 client fetch
+ *   /api/public/homepage-events，page 本身只剩纯静态渲染，build 时随
+ *   [locale] generateStaticParams 一起预渲染（zh + en 两份），Vercel
+ *   Function 调用归零。
  *
- * TODO: 把 FloatWindow 的 event prop 移到 client 自己 fetch（参考 Hero
- * 的 ActivityTicker 模式），让首页变 ●（SSG）。当前先保持 ƒ，等下一轮
- * 优化。
+ * force-static + setRequestLocale 双保险：让 next-intl 不退回 dynamic。
  */
+export const dynamic = "force-static";
+
 export default async function HomePage({ params }: Props) {
   const { locale } = await params;
   if (!hasLocale(routing.locales, locale)) notFound();
   setRequestLocale(locale);
-
-  const homepageEvents = await fetchHomepageEvents();
-  // FloatWindow 只展示"第一条未过期活动"；fetchHomepageEvents 已把未过期排前面
-  const latestActive = homepageEvents.find((e) => !e.deprecated) ?? null;
 
   return (
     <>
@@ -39,7 +37,7 @@ export default async function HomePage({ params }: Props) {
       <Hero />
       <DispatchNetwork />
       <Footer />
-      <FloatWindow event={latestActive} />
+      <FloatWindow />
     </>
   );
 }

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { setRequestLocale } from "next-intl/server";
 import { hasLocale } from "next-intl";
 import { notFound } from "next/navigation";
@@ -40,4 +41,34 @@ export default async function HomePage({ params }: Props) {
       <FloatWindow />
     </>
   );
+}
+
+/**
+ * 首页 metadata：覆盖 root layout 的 alternates。
+ *
+ * canonical 指向当前 locale 的首页（/zh 或 /en），让两个 locale 各自有独立
+ * 的 canonical URL，避免 Google 把它们当成重复内容互相争 PageRank。
+ *
+ * languages（hreflang）三向声明，告诉 Google 同一首页的另一语言版本在哪。
+ */
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale } = await params;
+  if (!hasLocale(routing.locales, locale)) notFound();
+  setRequestLocale(locale);
+
+  return {
+    alternates: {
+      canonical: `/${locale}`,
+      languages: {
+        "zh-CN": "/zh",
+        "en-US": "/en",
+        "x-default": "/zh",
+      },
+    },
+    openGraph: {
+      url: `/${locale}`,
+      locale: locale === "en" ? "en_US" : "zh_CN",
+      alternateLocale: locale === "en" ? ["zh_CN"] : ["en_US"],
+    },
+  };
 }

--- a/app/api/public/homepage-events/route.ts
+++ b/app/api/public/homepage-events/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { fetchHomepageEvents } from "@/lib/events-fetch";
+
+/**
+ * 首页活动数据的客户端代理 API。
+ *
+ * 为什么需要这个端点（i18n 改造收尾，2026-05）：
+ *   首页 page.tsx 之前用 server component await fetchHomepageEvents()，把
+ *   首页钉成 ƒ Dynamic（任何 server fetch 都阻挡 SSG）。改造让 FloatWindow /
+ *   ActivityTicker 改 client component 自己 fetch，但他们直接打后端会涉及
+ *   CORS + NEXT_PUBLIC_BACKEND_URL 暴露。走自家 API 中转更干净：
+ *   - 浏览器调 /api/public/homepage-events（同源，无 CORS）
+ *   - 路由 server-side 调后端 /api/events（BACKEND_URL 不暴露）
+ *   - revalidate: 300 让 Next.js Data Cache 命中 5 分钟内的请求，最多
+ *     每 5min 一次 server fetch，Vercel CPU 几乎为零
+ *
+ * 即使首页 SSG，每个浏览器加载会发一次这条请求，但因为 fetch cache + ISR
+ * 命中（HTTP 304），Vercel Function 大部分时候不会冷启动。
+ */
+
+// ISR：5 分钟缓存（与 lib/events-fetch.ts 内部 revalidate 对齐）
+export const revalidate = 300;
+
+export async function GET() {
+  const events = await fetchHomepageEvents();
+  return NextResponse.json(events, {
+    headers: {
+      // 浏览器侧也缓存 5 分钟，刷新页面期间不再打 origin
+      "cache-control": "public, max-age=300, s-maxage=300",
+    },
+  });
+}

--- a/app/api/public/top-docs/route.ts
+++ b/app/api/public/top-docs/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from "next/server";
+
+interface TopDocDto {
+  path: string;
+  title: string;
+  views: number;
+}
+
+/**
+ * 首页 "本周最热" 数据的客户端代理 API。
+ *
+ * 与 /api/public/homepage-events 同一思路（i18n 改造收尾，2026-05）：
+ *   原来的 HotDocsPreview server component 直接 await fetchTopDocs，server
+ *   fetch 让 Hero 段所在的整个首页 RSC tree 变 ƒ Dynamic。改为 client fetch
+ *   走自家代理：
+ *   - 浏览器调 /api/public/top-docs（同源，无 CORS）
+ *   - 路由 server-side 调后端 /analytics/top-docs（BACKEND_URL 不暴露）
+ *   - revalidate=300 让 Next.js Data Cache 命中，最多每 5min 一次后端调用
+ *   - 浏览器侧 cache-control 5min 复用响应
+ *
+ * 后端拒服务时静默返回空数组，HotDocsPreview 显示"empty"。
+ */
+export const revalidate = 300;
+
+export async function GET() {
+  const backendUrl = process.env.BACKEND_URL;
+  if (!backendUrl) {
+    return NextResponse.json([], {
+      headers: { "cache-control": "public, max-age=300, s-maxage=300" },
+    });
+  }
+
+  try {
+    const res = await fetch(
+      `${backendUrl}/analytics/top-docs?window=7d&limit=5`,
+      {
+        next: { revalidate: 300 },
+        // UA 带 InvolutionHell-SSR token，让 Cloudflare Bot Fight Mode 放行
+        // （CF Custom Rule 用这个 token 识别"自己人"）。
+        headers: {
+          accept: "application/json",
+          "user-agent": "InvolutionHell-SSR/1.0 (+https://involutionhell.com)",
+        },
+      },
+    );
+    if (!res.ok) {
+      return NextResponse.json([], {
+        headers: { "cache-control": "public, max-age=60" },
+      });
+    }
+    const json = await res.json();
+    const data: TopDocDto[] = Array.isArray(json?.data) ? json.data : [];
+    return NextResponse.json(data, {
+      headers: { "cache-control": "public, max-age=300, s-maxage=300" },
+    });
+  } catch {
+    return NextResponse.json([], {
+      headers: { "cache-control": "public, max-age=60" },
+    });
+  }
+}

--- a/app/components/ActivityTicker.tsx
+++ b/app/components/ActivityTicker.tsx
@@ -1,17 +1,23 @@
+"use client";
+
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
-import { fetchHomepageEvents, type HomepageEvent } from "@/lib/events-fetch";
+import type { HomepageEvent } from "@/lib/events-fetch";
 
 /**
  * 首页顶部活动轮播。
  *
  * 数据源：后端 /api/events（管理员在 /admin/events 维护）。
- * 后端失败时返回空数组，组件 return null 不渲染轮播（整条不显示）。
  *
- * 为什么是 Server Component：
- * - 没有交互状态（纯 CSS 跑马灯动画）
- * - SSR 时已经能拿到数据，避免 client fetch 造成首屏闪烁
- * - revalidate: 300 让 Neon 压力稳定在每 5min 一次 SSR
+ * 为什么是 Client Component（i18n 改造收尾，2026-05）：
+ *   原来是 async server component，server fetch 让首页 page.tsx 整页变 ƒ
+ *   Dynamic（任何 server fetch 都阻挡 SSG）。改 client + 自家 ISR 代理后：
+ *   - 首页 page.tsx 可以纯静态预渲染，Vercel CPU 归零
+ *   - 数据走 /api/public/homepage-events（revalidate=300，5min 缓存）
+ *   - 浏览器拿到 304 命中本地缓存，不打 Vercel Function
+ *   - 首屏没有 ticker（events 还在 fetch），hydrate 后出现，不影响 LCP
+ *     （ticker 不是 LCP 元素）
  */
 
 const MAX_ITEMS = 3;
@@ -21,9 +27,23 @@ type ActivityTickerProps = {
   className?: string;
 };
 
-export async function ActivityTicker({ className }: ActivityTickerProps) {
-  const all = await fetchHomepageEvents();
-  const events = all.slice(0, MAX_ITEMS);
+export function ActivityTicker({ className }: ActivityTickerProps) {
+  const [events, setEvents] = useState<HomepageEvent[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/public/homepage-events", { cache: "force-cache" })
+      .then((r) => (r.ok ? r.json() : []))
+      .then((data: HomepageEvent[]) => {
+        if (!cancelled) setEvents(data.slice(0, MAX_ITEMS));
+      })
+      .catch(() => {
+        // 静默失败：ticker 不显示比报错更友好
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   if (events.length === 0) return null;
 

--- a/app/components/HotDocsPreview.tsx
+++ b/app/components/HotDocsPreview.tsx
@@ -1,5 +1,8 @@
+"use client";
+
+import { useEffect, useState } from "react";
 import Link from "next/link";
-import { getTranslations } from "next-intl/server";
+import { useTranslations } from "next-intl";
 
 interface TopDocDto {
   path: string;
@@ -7,44 +10,9 @@ interface TopDocDto {
   views: number;
 }
 
-async function fetchTopDocs(): Promise<TopDocDto[]> {
-  const backendUrl = process.env.BACKEND_URL;
-  if (!backendUrl) {
-    if (process.env.NODE_ENV !== "production") {
-      console.warn(
-        "[HotDocsPreview] BACKEND_URL 未配置，跳过 Top Docs 请求。本地请在 .env.local 设置。",
-      );
-    }
-    return [];
-  }
-  try {
-    const res = await fetch(
-      `${backendUrl}/analytics/top-docs?window=7d&limit=5`,
-      {
-        next: { revalidate: 300 },
-        // UA 必须带 "InvolutionHell-SSR" token，否则 Cloudflare Bot Fight Mode
-        // 会按 Vercel runner IP 信誉判定为 bot 拦截（CF Custom Rule 用这个
-        // token 识别"自己人"放行）。其他 SSR fetcher（fetchProfile / events /
-        // feed）都已经带，唯独本组件之前漏了导致首页 "本周最热" 一直空。
-        headers: {
-          accept: "application/json",
-          "user-agent": "InvolutionHell-SSR/1.0 (+https://involutionhell.com)",
-        },
-      },
-    );
-    if (!res.ok) return [];
-    const json = await res.json();
-    return Array.isArray(json?.data) ? json.data : [];
-  } catch {
-    return [];
-  }
-}
-
 /**
  * HotDocsPreview 的骨架屏。
- * 在首页被 <Suspense> 包裹时作为 fallback，让页面 shell 先 stream 给浏览器，
- * 等后端 /analytics/top-docs 返回后再替换成真实内容。
- * 结构刻意贴合真组件（同样的 5 行 + 标题栏），避免 CLS。
+ * 数据加载期间显示，避免 CLS（结构刻意贴合真组件，5 行 + 标题栏）。
  */
 export function HotDocsPreviewSkeleton() {
   return (
@@ -76,9 +44,39 @@ export function HotDocsPreviewSkeleton() {
   );
 }
 
-export async function HotDocsPreview() {
-  const docs = await fetchTopDocs();
-  const t = await getTranslations("hotDocs");
+/**
+ * HotDocsPreview - 首页 "本周最热" 文档榜。
+ *
+ * 客户端化（i18n 改造收尾，2026-05）：
+ *   原来是 async server component（await fetchTopDocs + getTranslations），
+ *   server fetch 让首页 RSC tree 整体 ƒ Dynamic。改 client 后：
+ *   - 数据走 /api/public/top-docs（revalidate=300 ISR + 浏览器 5min 缓存）
+ *   - 翻译用 next-intl 的 useTranslations（client hook）
+ *   - 首屏先显示 Skeleton，hydrate 后 fetch + 替换为真实内容（不影响 LCP）
+ */
+export function HotDocsPreview() {
+  const t = useTranslations("hotDocs");
+  const [docs, setDocs] = useState<TopDocDto[] | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/public/top-docs", { cache: "force-cache" })
+      .then((r) => (r.ok ? r.json() : []))
+      .then((data: TopDocDto[]) => {
+        if (!cancelled) setDocs(data);
+      })
+      .catch(() => {
+        if (!cancelled) setDocs([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // fetch 未完成：渲染 Skeleton（与 Suspense fallback 同形态）
+  if (docs === null) {
+    return <HotDocsPreviewSkeleton />;
+  }
 
   return (
     <div className="border border-[var(--foreground)] p-6 bg-[var(--background)]">

--- a/app/components/float-window/FloatWindow.tsx
+++ b/app/components/float-window/FloatWindow.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { usePathname } from "next/navigation";
 import { motion, AnimatePresence } from "motion/react";
 import type { HomepageEvent } from "@/lib/events-fetch";
@@ -10,26 +10,43 @@ import styles from "./FloatWindow.module.css";
 
 /**
  * FloatWindow - 复古报纸风格的活动预告悬浮窗。
- * 仅显示最新的一条活动，仅在首页 (/) 可见。
+ * 仅显示最新的一条活动，仅在首页（locale 段下的 /） 可见。
  *
- * 数据来源：
- * - 之前从 data/event.json 直接 import
- * - 现在由上游 Server Component（app/page.tsx）调 lib/events-fetch.ts 拉 /api/events
- *   后通过 event prop 传进来；后端失败时 fetch 内部会 fallback 到 JSON
+ * 数据来源（i18n 改造收尾，2026-05）：
+ *   - 之前由上游 Server Component（app/page.tsx）调 fetchHomepageEvents
+ *     后通过 event prop 传入；这让首页变 ƒ Dynamic
+ *   - 改为本组件自己 client fetch /api/public/homepage-events，首页可以
+ *     SSG 静态化。组件仍然按"第一条未过期活动"的逻辑挑一条展示。
  */
 
-interface FloatWindowProps {
-  /** 要展示的单条活动；null 或已过期时组件不渲染 */
-  event: HomepageEvent | null;
-}
-
-export function FloatWindow({ event }: FloatWindowProps) {
+export function FloatWindow() {
   const pathname = usePathname();
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [isDismissed, setIsDismissed] = useState(false);
+  const [event, setEvent] = useState<HomepageEvent | null>(null);
 
-  // 仅在首页 (/) 可见
-  const isHomePage = pathname === "/";
+  // 仅在首页（/zh、/en 或裸 /）可见。i18n 段化后 pathname 是 /<locale>。
+  const isHomePage =
+    pathname === "/" || pathname === "/zh" || pathname === "/en";
+
+  useEffect(() => {
+    if (!isHomePage) return;
+    let cancelled = false;
+    fetch("/api/public/homepage-events", { cache: "force-cache" })
+      .then((r) => (r.ok ? r.json() : []))
+      .then((data: HomepageEvent[]) => {
+        if (cancelled) return;
+        // 未过期的活动排前面（API 已排序），挑第一条非 deprecated
+        const latest = data.find((e) => !e.deprecated) ?? null;
+        setEvent(latest);
+      })
+      .catch(() => {
+        // 静默失败：组件不显示比报错更友好
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isHomePage]);
 
   const handleDismiss = useCallback(() => setIsDismissed(true), []);
   const handleToggle = useCallback(() => setIsCollapsed((prev) => !prev), []);

--- a/dev_docs/i18n_url_routing.md
+++ b/dev_docs/i18n_url_routing.md
@@ -143,6 +143,76 @@ frontmatter 不需要写 `lang` 字段。fumadocs 按文件名后缀识别。
 `lib/source.ts` 配 `fallbackLanguage: "zh"`：访问 `/en/docs/<slug>` 但 `.en.mdx`
 不存在时，自动渲染原文（zh）。文档站合理体验（缺译显示中文 > 显示空白）。
 
+## 加新 user-facing 路由
+
+新建 page 时直接抄这个 boilerplate，就能保证 SSG + i18n 同时正确：
+
+```tsx
+// app/[locale]/<your-route>/page.tsx
+import type { Metadata } from "next";
+import { setRequestLocale } from "next-intl/server";
+import { hasLocale } from "next-intl";
+import { notFound } from "next/navigation";
+import { routing } from "@/i18n/routing";
+
+interface Props {
+  params: Promise<{ locale: string }>;
+}
+
+// 没 server fetch 才能加 force-static；如果 page 里有 await fetch(...)
+// 就别加（会和 fetch 冲突报错），靠 setRequestLocale 也能让 RSC 静态化。
+export const dynamic = "force-static";
+
+export default async function Page({ params }: Props) {
+  const { locale } = await params;
+  if (!hasLocale(routing.locales, locale)) notFound();
+  setRequestLocale(locale); // ← 必须，且必须排在任何 next-intl hook 之前
+
+  // ... 业务逻辑
+  return <div>...</div>;
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale } = await params;
+  if (!hasLocale(routing.locales, locale)) notFound();
+  setRequestLocale(locale);
+
+  return {
+    alternates: {
+      canonical: `/${locale}/<your-route>`,
+      languages: {
+        "zh-CN": "/zh/<your-route>",
+        "en-US": "/en/<your-route>",
+        "x-default": "/zh/<your-route>",
+      },
+    },
+  };
+}
+```
+
+**几条容易踩的坑**：
+
+1. **`setRequestLocale` 必须在第一位**。排在 `useTranslations` / `getMessages`
+   / `getTranslations` 之前。否则 next-intl 会回退到从 cookies/headers 推断
+   locale，整页变 dynamic。
+2. **导航 API 用 `@/i18n/navigation` 而不是 `next/navigation`**。在 [locale]
+   段下的客户端组件如果 `import { useRouter } from 'next/navigation'`，
+   `router.push("/foo")` 会跳到 `/foo` 而不是 `/<locale>/foo`，丢 locale 段。
+   ```tsx
+   // ✅ 正确
+   import { useRouter, Link } from "@/i18n/navigation";
+   // ❌ 错误（在 [locale] 段下不要用）
+   import { useRouter } from "next/navigation";
+   import Link from "next/link";
+   ```
+3. **components 在 `app/components/`（不在 [locale] 下）**。组件本身不需要
+   locale 段，导入用 `@/app/components/X`。
+4. **server fetch 让 page 退回 dynamic**。如果非要 fetch backend，参考首页
+   的做法：建一个 `/api/public/<x>` ISR 代理（revalidate=300），组件改 client
+   useEffect fetch，page 本身保持纯静态。
+5. **layout.tsx 嵌套时也要调 `setRequestLocale`**。Next.js 独立渲染 layout
+   和 page；page 调了 layout 没调照样退化 dynamic。每层都要补。
+
 ## 切换语言
 
 `<LocaleToggle />` 用 next-intl 的 `useRouter().replace(pathname, { locale })`。

--- a/generated/doc-contributors.json
+++ b/generated/doc-contributors.json
@@ -1,13 +1,14 @@
 {
   "repo": "InvolutionHell/involutionhell",
-  "generatedAt": "2026-04-27T15:37:11.402Z",
-  "docsDir": "app/docs",
+  "generatedAt": "2026-05-06T15:27:30.720Z",
+  "docsDir": "content/docs",
   "totalDocs": 153,
   "results": [
     {
       "docId": "ld59a8z1v84ig4rlr0p0n2a9",
-      "path": "app/docs/career/events/coffee-chat.md",
+      "path": "content/docs/career/events/coffee-chat.md",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 2
       },
       "contributors": [
@@ -21,8 +22,8 @@
         },
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -31,9 +32,10 @@
     },
     {
       "docId": "s8w3d2p5k9m4h7z1x0c2a8r6",
-      "path": "app/docs/career/events/event-takeway.md",
+      "path": "content/docs/career/events/event-takeway.md",
       "contributorStats": {
         "73457237": 1,
+        "114939201": 1,
         "163523387": 2
       },
       "contributors": [
@@ -46,32 +48,34 @@
           "htmlUrl": "https://github.com/Mira190"
         },
         {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
+        {
           "githubId": "73457237",
           "contributions": 1,
           "lastContributedAt": "2026-02-08T15:28:24.000Z",
           "login": "TSK-Glofy",
           "avatarUrl": "https://avatars.githubusercontent.com/u/73457237?v=4",
           "htmlUrl": "https://github.com/TSK-Glofy"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "crr0001index2026041800000001",
-      "path": "app/docs/career/index.mdx",
-      "contributorStats": {},
+      "path": "content/docs/career/index.mdx",
+      "contributorStats": {
+        "114939201": 1
+      },
       "contributors": [
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -80,11 +84,20 @@
     },
     {
       "docId": "u68pjetu592c9zvs3f5xa82j",
-      "path": "app/docs/career/interview-prep/bq.md",
+      "path": "content/docs/career/interview-prep/bq.md",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 1
       },
       "contributors": [
+        {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
         {
           "githubId": "163523387",
           "contributions": 1,
@@ -92,21 +105,14 @@
           "login": "Mira190",
           "avatarUrl": "https://avatars.githubusercontent.com/u/163523387?v=4",
           "htmlUrl": "https://github.com/Mira190"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "fkk8ghklsr15a0s3vcxnswnj",
-      "path": "app/docs/career/interview-prep/interview-tips.mdx",
+      "path": "content/docs/career/interview-prep/interview-tips.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 3
       },
       "contributors": [
@@ -120,8 +126,8 @@
         },
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -130,15 +136,15 @@
     },
     {
       "docId": "w9ffo1wycpbz50051cb7lyo5",
-      "path": "app/docs/career/interview-prep/leetcode/[121]买卖股票的最佳时期_translated.md",
+      "path": "content/docs/career/interview-prep/leetcode/[121]买卖股票的最佳时期_translated.md",
       "contributorStats": {
-        "114939201": 3
+        "114939201": 4
       },
       "contributors": [
         {
           "githubId": "114939201",
-          "contributions": 3,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 4,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -147,15 +153,15 @@
     },
     {
       "docId": "jcqhknk5z2xr3rfqn49me4j9",
-      "path": "app/docs/career/interview-prep/leetcode/[1333]餐厅过滤器_translated.md",
+      "path": "content/docs/career/interview-prep/leetcode/[1333]餐厅过滤器_translated.md",
       "contributorStats": {
-        "114939201": 3
+        "114939201": 4
       },
       "contributors": [
         {
           "githubId": "114939201",
-          "contributions": 3,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 4,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -164,15 +170,15 @@
     },
     {
       "docId": "u0szm4sv8mr3on3ivbfo5r84",
-      "path": "app/docs/career/interview-prep/leetcode/[146]LRU 缓存_translated.md",
+      "path": "content/docs/career/interview-prep/leetcode/[146]LRU 缓存_translated.md",
       "contributorStats": {
-        "114939201": 3
+        "114939201": 4
       },
       "contributors": [
         {
           "githubId": "114939201",
-          "contributions": 3,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 4,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -181,15 +187,15 @@
     },
     {
       "docId": "zuoplhoodv7tzfgku0pwzi6w",
-      "path": "app/docs/career/interview-prep/leetcode/[1545]找出第 N 个二进制字符串中的第 K 位.md",
+      "path": "content/docs/career/interview-prep/leetcode/[1545]找出第 N 个二进制字符串中的第 K 位.md",
       "contributorStats": {
-        "114939201": 3
+        "114939201": 4
       },
       "contributors": [
         {
           "githubId": "114939201",
-          "contributions": 3,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 4,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -198,15 +204,15 @@
     },
     {
       "docId": "rv6egbynttb4mt1n0412bue0",
-      "path": "app/docs/career/interview-prep/leetcode/[213]打家劫舍 II_translated.md",
+      "path": "content/docs/career/interview-prep/leetcode/[213]打家劫舍 II_translated.md",
       "contributorStats": {
-        "114939201": 3
+        "114939201": 4
       },
       "contributors": [
         {
           "githubId": "114939201",
-          "contributions": 3,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 4,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -215,15 +221,15 @@
     },
     {
       "docId": "pe6o8l76945uo7aqv79ddhii",
-      "path": "app/docs/career/interview-prep/leetcode/[2490]回环句_translated.md",
+      "path": "content/docs/career/interview-prep/leetcode/[2490]回环句_translated.md",
       "contributorStats": {
-        "114939201": 3
+        "114939201": 4
       },
       "contributors": [
         {
           "githubId": "114939201",
-          "contributions": 3,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 4,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -232,15 +238,15 @@
     },
     {
       "docId": "naxatag8x2nnvkhbwdfc1azc",
-      "path": "app/docs/career/interview-prep/leetcode/[2562]找出数组的串联值_translated.md",
+      "path": "content/docs/career/interview-prep/leetcode/[2562]找出数组的串联值_translated.md",
       "contributorStats": {
-        "114939201": 3
+        "114939201": 4
       },
       "contributors": [
         {
           "githubId": "114939201",
-          "contributions": 3,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 4,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -249,15 +255,15 @@
     },
     {
       "docId": "p9gvb8klqv990cq88j4l76zy",
-      "path": "app/docs/career/interview-prep/leetcode/[2582]递枕头_translated.md",
+      "path": "content/docs/career/interview-prep/leetcode/[2582]递枕头_translated.md",
       "contributorStats": {
-        "114939201": 3
+        "114939201": 4
       },
       "contributors": [
         {
           "githubId": "114939201",
-          "contributions": 3,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 4,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -266,15 +272,15 @@
     },
     {
       "docId": "ytg2bds2dnhzw37nrb3vassy",
-      "path": "app/docs/career/interview-prep/leetcode/1004_translated.md",
+      "path": "content/docs/career/interview-prep/leetcode/1004_translated.md",
       "contributorStats": {
-        "114939201": 3
+        "114939201": 4
       },
       "contributors": [
         {
           "githubId": "114939201",
-          "contributions": 3,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 4,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -283,16 +289,16 @@
     },
     {
       "docId": "p8igr19xfxnuyo2lpngnr6fg",
-      "path": "app/docs/career/interview-prep/leetcode/1234. 替换子串得到平衡字符串_translated.md",
+      "path": "content/docs/career/interview-prep/leetcode/1234. 替换子串得到平衡字符串_translated.md",
       "contributorStats": {
         "7187663": 1,
-        "114939201": 5
+        "114939201": 6
       },
       "contributors": [
         {
           "githubId": "114939201",
-          "contributions": 5,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 6,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -309,15 +315,15 @@
     },
     {
       "docId": "ylpucy1rbbnfpe3t62u8kcfq",
-      "path": "app/docs/career/interview-prep/leetcode/142.环形链表II_translated.md",
+      "path": "content/docs/career/interview-prep/leetcode/142.环形链表II_translated.md",
       "contributorStats": {
-        "114939201": 6
+        "114939201": 7
       },
       "contributors": [
         {
           "githubId": "114939201",
-          "contributions": 6,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 7,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -326,15 +332,15 @@
     },
     {
       "docId": "bsf0yz1zrmlz7masrdmq8fq6",
-      "path": "app/docs/career/interview-prep/leetcode/1653. 使字符串平衡的最少删除次数_translated.md",
+      "path": "content/docs/career/interview-prep/leetcode/1653. 使字符串平衡的最少删除次数_translated.md",
       "contributorStats": {
-        "114939201": 3
+        "114939201": 4
       },
       "contributors": [
         {
           "githubId": "114939201",
-          "contributions": 3,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 4,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -343,15 +349,15 @@
     },
     {
       "docId": "ska0npc89ja1r4pdt2qow79u",
-      "path": "app/docs/career/interview-prep/leetcode/1664生成平衡数组的方案数_translated.md",
+      "path": "content/docs/career/interview-prep/leetcode/1664生成平衡数组的方案数_translated.md",
       "contributorStats": {
-        "114939201": 3
+        "114939201": 4
       },
       "contributors": [
         {
           "githubId": "114939201",
-          "contributions": 3,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 4,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -360,15 +366,15 @@
     },
     {
       "docId": "n38sohi8zlxesl82tgv854kj",
-      "path": "app/docs/career/interview-prep/leetcode/1825求出 MK 平均值_translated.md",
+      "path": "content/docs/career/interview-prep/leetcode/1825求出 MK 平均值_translated.md",
       "contributorStats": {
-        "114939201": 3
+        "114939201": 4
       },
       "contributors": [
         {
           "githubId": "114939201",
-          "contributions": 3,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 4,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -377,15 +383,15 @@
     },
     {
       "docId": "chb8ee5s38v8gh751n9e5znj",
-      "path": "app/docs/career/interview-prep/leetcode/1828统计一个圆中点的数目_translated.md",
+      "path": "content/docs/career/interview-prep/leetcode/1828统计一个圆中点的数目_translated.md",
       "contributorStats": {
-        "114939201": 3
+        "114939201": 4
       },
       "contributors": [
         {
           "githubId": "114939201",
-          "contributions": 3,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 4,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -394,15 +400,15 @@
     },
     {
       "docId": "ksw2vic4alf1tdnnueay81g8",
-      "path": "app/docs/career/interview-prep/leetcode/2131. 连接两字母单词得到的最长回文串.md",
+      "path": "content/docs/career/interview-prep/leetcode/2131. 连接两字母单词得到的最长回文串.md",
       "contributorStats": {
-        "114939201": 3
+        "114939201": 4
       },
       "contributors": [
         {
           "githubId": "114939201",
-          "contributions": 3,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 4,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -411,15 +417,15 @@
     },
     {
       "docId": "k4btd9x3l3xnnl4dnr64d8cq",
-      "path": "app/docs/career/interview-prep/leetcode/219_translated.md",
+      "path": "content/docs/career/interview-prep/leetcode/219_translated.md",
       "contributorStats": {
-        "114939201": 3
+        "114939201": 4
       },
       "contributors": [
         {
           "githubId": "114939201",
-          "contributions": 3,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 4,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -428,15 +434,15 @@
     },
     {
       "docId": "lzrh7ftq3kegsyx8gimonrfu",
-      "path": "app/docs/career/interview-prep/leetcode/2241. Design an ATM Machine.md",
+      "path": "content/docs/career/interview-prep/leetcode/2241. Design an ATM Machine.md",
       "contributorStats": {
-        "114939201": 3
+        "114939201": 4
       },
       "contributors": [
         {
           "githubId": "114939201",
-          "contributions": 3,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 4,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -445,15 +451,15 @@
     },
     {
       "docId": "a6inw303oslb7i5tcqj5xxx4",
-      "path": "app/docs/career/interview-prep/leetcode/2270. Number of Ways to Split Array.md",
+      "path": "content/docs/career/interview-prep/leetcode/2270. Number of Ways to Split Array.md",
       "contributorStats": {
-        "114939201": 3
+        "114939201": 4
       },
       "contributors": [
         {
           "githubId": "114939201",
-          "contributions": 3,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 4,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -462,15 +468,15 @@
     },
     {
       "docId": "mssz5wgh368yp55qcvs1op5e",
-      "path": "app/docs/career/interview-prep/leetcode/2293_translated.md",
+      "path": "content/docs/career/interview-prep/leetcode/2293_translated.md",
       "contributorStats": {
-        "114939201": 3
+        "114939201": 4
       },
       "contributors": [
         {
           "githubId": "114939201",
-          "contributions": 3,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 4,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -479,15 +485,15 @@
     },
     {
       "docId": "fxn6bn619g3a9l98l9vggpg1",
-      "path": "app/docs/career/interview-prep/leetcode/2299强密码检验器II_translated.md",
+      "path": "content/docs/career/interview-prep/leetcode/2299强密码检验器II_translated.md",
       "contributorStats": {
-        "114939201": 3
+        "114939201": 4
       },
       "contributors": [
         {
           "githubId": "114939201",
-          "contributions": 3,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 4,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -496,15 +502,15 @@
     },
     {
       "docId": "mc2rjsq7syibclikyhomsbft",
-      "path": "app/docs/career/interview-prep/leetcode/2309兼具大小写的最好英文字母_translated.md",
+      "path": "content/docs/career/interview-prep/leetcode/2309兼具大小写的最好英文字母_translated.md",
       "contributorStats": {
-        "114939201": 4
+        "114939201": 5
       },
       "contributors": [
         {
           "githubId": "114939201",
-          "contributions": 4,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 5,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -513,15 +519,15 @@
     },
     {
       "docId": "hiqhki2z4v6oy0jstrcs7im0",
-      "path": "app/docs/career/interview-prep/leetcode/2335. 装满杯子需要的最短总时长_translated.md",
+      "path": "content/docs/career/interview-prep/leetcode/2335. 装满杯子需要的最短总时长_translated.md",
       "contributorStats": {
-        "114939201": 3
+        "114939201": 4
       },
       "contributors": [
         {
           "githubId": "114939201",
-          "contributions": 3,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 4,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -530,15 +536,15 @@
     },
     {
       "docId": "s3w19zdm6yhkhj4o0ba3kbal",
-      "path": "app/docs/career/interview-prep/leetcode/2341. 数组能形成多少数对_translated.md",
+      "path": "content/docs/career/interview-prep/leetcode/2341. 数组能形成多少数对_translated.md",
       "contributorStats": {
-        "114939201": 3
+        "114939201": 4
       },
       "contributors": [
         {
           "githubId": "114939201",
-          "contributions": 3,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 4,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -547,15 +553,15 @@
     },
     {
       "docId": "lnx1bszj5aqqqfa50sejjv7n",
-      "path": "app/docs/career/interview-prep/leetcode/2639. 查询网格图中每一列的宽度_translated.md",
+      "path": "content/docs/career/interview-prep/leetcode/2639. 查询网格图中每一列的宽度_translated.md",
       "contributorStats": {
-        "114939201": 3
+        "114939201": 4
       },
       "contributors": [
         {
           "githubId": "114939201",
-          "contributions": 3,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 4,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -564,15 +570,15 @@
     },
     {
       "docId": "clx9mmqqvxipdfamqciuo146",
-      "path": "app/docs/career/interview-prep/leetcode/2679.矩阵中的和_translated.md",
+      "path": "content/docs/career/interview-prep/leetcode/2679.矩阵中的和_translated.md",
       "contributorStats": {
-        "114939201": 3
+        "114939201": 4
       },
       "contributors": [
         {
           "githubId": "114939201",
-          "contributions": 3,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 4,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -581,15 +587,15 @@
     },
     {
       "docId": "y0ntwlksnvj7ymuapqvkvmwr",
-      "path": "app/docs/career/interview-prep/leetcode/2894. 分类求和并作差.md",
+      "path": "content/docs/career/interview-prep/leetcode/2894. 分类求和并作差.md",
       "contributorStats": {
-        "114939201": 3
+        "114939201": 4
       },
       "contributors": [
         {
           "githubId": "114939201",
-          "contributions": 3,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 4,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -598,15 +604,15 @@
     },
     {
       "docId": "r12u8o7j73oxhbvgphi939fb",
-      "path": "app/docs/career/interview-prep/leetcode/3072. 将元素分配到两个数组中 II_translated.md",
+      "path": "content/docs/career/interview-prep/leetcode/3072. 将元素分配到两个数组中 II_translated.md",
       "contributorStats": {
-        "114939201": 4
+        "114939201": 5
       },
       "contributors": [
         {
           "githubId": "114939201",
-          "contributions": 4,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 5,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -615,15 +621,15 @@
     },
     {
       "docId": "o3knuvbpnki6isfjv3g5ohau",
-      "path": "app/docs/career/interview-prep/leetcode/3138. Minimum Length of Anagram Concatenation.md",
+      "path": "content/docs/career/interview-prep/leetcode/3138. Minimum Length of Anagram Concatenation.md",
       "contributorStats": {
-        "114939201": 3
+        "114939201": 4
       },
       "contributors": [
         {
           "githubId": "114939201",
-          "contributions": 3,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 4,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -632,15 +638,15 @@
     },
     {
       "docId": "udm0daiek9dr22xq4doep5w4",
-      "path": "app/docs/career/interview-prep/leetcode/345. 反转字符串中的元音字母_translated.md",
+      "path": "content/docs/career/interview-prep/leetcode/345. 反转字符串中的元音字母_translated.md",
       "contributorStats": {
-        "114939201": 3
+        "114939201": 4
       },
       "contributors": [
         {
           "githubId": "114939201",
-          "contributions": 3,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 4,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -649,15 +655,15 @@
     },
     {
       "docId": "jv8qj3ljyr2uomaehnv0l77k",
-      "path": "app/docs/career/interview-prep/leetcode/42.md",
+      "path": "content/docs/career/interview-prep/leetcode/42.md",
       "contributorStats": {
-        "114939201": 3
+        "114939201": 4
       },
       "contributors": [
         {
           "githubId": "114939201",
-          "contributions": 3,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 4,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -666,15 +672,15 @@
     },
     {
       "docId": "mxt0ux1zpbzph4nuxz51eyg7",
-      "path": "app/docs/career/interview-prep/leetcode/46.全排列.md",
+      "path": "content/docs/career/interview-prep/leetcode/46.全排列.md",
       "contributorStats": {
-        "114939201": 3
+        "114939201": 4
       },
       "contributors": [
         {
           "githubId": "114939201",
-          "contributions": 3,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 4,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -683,15 +689,15 @@
     },
     {
       "docId": "wen0bbo8m93oih1mx6sva9sh",
-      "path": "app/docs/career/interview-prep/leetcode/538.把二叉搜索树转换为累加树_translated.md",
+      "path": "content/docs/career/interview-prep/leetcode/538.把二叉搜索树转换为累加树_translated.md",
       "contributorStats": {
-        "114939201": 4
+        "114939201": 5
       },
       "contributors": [
         {
           "githubId": "114939201",
-          "contributions": 4,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 5,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -700,15 +706,15 @@
     },
     {
       "docId": "kw44if3s2zi4w2gs1gfhxvoz",
-      "path": "app/docs/career/interview-prep/leetcode/6323. 将钱分给最多的儿童_translated.md",
+      "path": "content/docs/career/interview-prep/leetcode/6323. 将钱分给最多的儿童_translated.md",
       "contributorStats": {
-        "114939201": 4
+        "114939201": 5
       },
       "contributors": [
         {
           "githubId": "114939201",
-          "contributions": 4,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 5,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -717,15 +723,15 @@
     },
     {
       "docId": "l358imxaj1mmtth6dydvu54s",
-      "path": "app/docs/career/interview-prep/leetcode/76最小覆盖子串_translated.md",
+      "path": "content/docs/career/interview-prep/leetcode/76最小覆盖子串_translated.md",
       "contributorStats": {
-        "114939201": 4
+        "114939201": 5
       },
       "contributors": [
         {
           "githubId": "114939201",
-          "contributions": 4,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 5,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -734,15 +740,15 @@
     },
     {
       "docId": "ryp6s59uwc10w2dywgs6f66h",
-      "path": "app/docs/career/interview-prep/leetcode/80_translated.md",
+      "path": "content/docs/career/interview-prep/leetcode/80_translated.md",
       "contributorStats": {
-        "114939201": 3
+        "114939201": 4
       },
       "contributors": [
         {
           "githubId": "114939201",
-          "contributions": 3,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 4,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -751,15 +757,15 @@
     },
     {
       "docId": "s0cadbu09dgu54q0zxttkx7z",
-      "path": "app/docs/career/interview-prep/leetcode/9021_TUT_3_25T1.md",
+      "path": "content/docs/career/interview-prep/leetcode/9021_TUT_3_25T1.md",
       "contributorStats": {
-        "114939201": 3
+        "114939201": 4
       },
       "contributors": [
         {
           "githubId": "114939201",
-          "contributions": 3,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 4,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -768,15 +774,15 @@
     },
     {
       "docId": "d5evrnoglwjvmyginjq84bl0",
-      "path": "app/docs/career/interview-prep/leetcode/93复原Ip地址.md",
+      "path": "content/docs/career/interview-prep/leetcode/93复原Ip地址.md",
       "contributorStats": {
-        "114939201": 3
+        "114939201": 4
       },
       "contributors": [
         {
           "githubId": "114939201",
-          "contributions": 3,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 4,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -785,15 +791,15 @@
     },
     {
       "docId": "axhoyzdtxoc82q58j1os57c8",
-      "path": "app/docs/career/interview-prep/leetcode/994.腐烂的橘子_translated.md",
+      "path": "content/docs/career/interview-prep/leetcode/994.腐烂的橘子_translated.md",
       "contributorStats": {
-        "114939201": 4
+        "114939201": 5
       },
       "contributors": [
         {
           "githubId": "114939201",
-          "contributions": 4,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 5,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -802,15 +808,15 @@
     },
     {
       "docId": "one7va4e0hvbq1eqhm6ww2kd",
-      "path": "app/docs/career/interview-prep/leetcode/brief_alternate 作业帮忙_translated.md",
+      "path": "content/docs/career/interview-prep/leetcode/brief_alternate 作业帮忙_translated.md",
       "contributorStats": {
-        "114939201": 3
+        "114939201": 4
       },
       "contributors": [
         {
           "githubId": "114939201",
-          "contributions": 3,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 4,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -819,15 +825,15 @@
     },
     {
       "docId": "fostlzqqx6l10qz1egd8dw5m",
-      "path": "app/docs/career/interview-prep/leetcode/Counting Stars-Inter-Uni Programming Contest.md",
+      "path": "content/docs/career/interview-prep/leetcode/Counting Stars-Inter-Uni Programming Contest.md",
       "contributorStats": {
-        "114939201": 3
+        "114939201": 4
       },
       "contributors": [
         {
           "githubId": "114939201",
-          "contributions": 3,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 4,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -836,15 +842,15 @@
     },
     {
       "docId": "aslw60tfyzxqga598pt4ociu",
-      "path": "app/docs/career/interview-prep/leetcode/index.mdx",
+      "path": "content/docs/career/interview-prep/leetcode/index.mdx",
       "contributorStats": {
-        "114939201": 4
+        "114939201": 5
       },
       "contributors": [
         {
           "githubId": "114939201",
-          "contributions": 4,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 5,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -853,15 +859,15 @@
     },
     {
       "docId": "qfvqmc1exp066falnsg97c5m",
-      "path": "app/docs/career/interview-prep/leetcode/剑指 Offer II 021. 删除链表的倒数第 n 个结点_translated.md",
+      "path": "content/docs/career/interview-prep/leetcode/剑指 Offer II 021. 删除链表的倒数第 n 个结点_translated.md",
       "contributorStats": {
-        "114939201": 3
+        "114939201": 4
       },
       "contributors": [
         {
           "githubId": "114939201",
-          "contributions": 3,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 4,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -870,8 +876,9 @@
     },
     {
       "docId": "cgo4lweflk5jx1hsncr8hshk",
-      "path": "app/docs/career/interview-prep/pre-interview.md",
+      "path": "content/docs/career/interview-prep/pre-interview.md",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 2
       },
       "contributors": [
@@ -885,8 +892,8 @@
         },
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -895,11 +902,20 @@
     },
     {
       "docId": "pne40puz5alzsf0f5jb0frbm",
-      "path": "app/docs/career/interview-prep/preparations-to-get-an-offer-as-a-student.mdx",
+      "path": "content/docs/career/interview-prep/preparations-to-get-an-offer-as-a-student.mdx",
       "contributorStats": {
-        "90535573": 1
+        "90535573": 1,
+        "114939201": 1
       },
       "contributors": [
+        {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
         {
           "githubId": "90535573",
           "contributions": 1,
@@ -907,24 +923,25 @@
           "login": "SiYG",
           "avatarUrl": "https://avatars.githubusercontent.com/u/90535573?v=4",
           "htmlUrl": "https://github.com/SiYG"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "gj4bn01un0s0841berfvwrn5",
-      "path": "app/docs/community/dev-tips/cloudflare-r2-sharex-free-image-hosting.mdx",
+      "path": "content/docs/community/dev-tips/cloudflare-r2-sharex-free-image-hosting.mdx",
       "contributorStats": {
+        "114939201": 1,
         "194795025": 1
       },
       "contributors": [
+        {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
         {
           "githubId": "194795025",
           "contributions": 1,
@@ -932,24 +949,25 @@
           "login": "LynPtl",
           "avatarUrl": "https://avatars.githubusercontent.com/u/194795025?v=4",
           "htmlUrl": "https://github.com/LynPtl"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "xqz5iiv3p52h6d9g3c0w2baf",
-      "path": "app/docs/community/dev-tips/CommonUsedMarkdown.md",
+      "path": "content/docs/community/dev-tips/CommonUsedMarkdown.md",
       "contributorStats": {
-        "73457237": 1
+        "73457237": 1,
+        "114939201": 1
       },
       "contributors": [
+        {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
         {
           "githubId": "73457237",
           "contributions": 1,
@@ -957,22 +975,15 @@
           "login": "TSK-Glofy",
           "avatarUrl": "https://avatars.githubusercontent.com/u/73457237?v=4",
           "htmlUrl": "https://github.com/TSK-Glofy"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "tksz80mfqqyzwzzer5p3uxtg",
-      "path": "app/docs/community/dev-tips/git101.mdx",
+      "path": "content/docs/community/dev-tips/git101.mdx",
       "contributorStats": {
         "88451018": 1,
+        "114939201": 1,
         "163523387": 3
       },
       "contributors": [
@@ -985,30 +996,39 @@
           "htmlUrl": "https://github.com/Mira190"
         },
         {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
+        {
           "githubId": "88451018",
           "contributions": 1,
           "lastContributedAt": "2025-10-15T03:17:10.000Z",
           "login": "richardkkk",
           "avatarUrl": "https://avatars.githubusercontent.com/u/88451018?v=4",
           "htmlUrl": "https://github.com/richardkkk"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "jee9yt8n8tmo8yclqujerw2x",
-      "path": "app/docs/community/dev-tips/index.mdx",
+      "path": "content/docs/community/dev-tips/index.mdx",
       "contributorStats": {
-        "73457237": 1
+        "73457237": 1,
+        "114939201": 1
       },
       "contributors": [
+        {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
         {
           "githubId": "73457237",
           "contributions": 1,
@@ -1016,24 +1036,25 @@
           "login": "TSK-Glofy",
           "avatarUrl": "https://avatars.githubusercontent.com/u/73457237?v=4",
           "htmlUrl": "https://github.com/TSK-Glofy"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "yxd2qpfl2li6092bjx8bz7vb",
-      "path": "app/docs/community/dev-tips/Katex/index.mdx",
+      "path": "content/docs/community/dev-tips/Katex/index.mdx",
       "contributorStats": {
-        "73457237": 1
+        "73457237": 1,
+        "114939201": 1
       },
       "contributors": [
+        {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
         {
           "githubId": "73457237",
           "contributions": 1,
@@ -1041,22 +1062,15 @@
           "login": "TSK-Glofy",
           "avatarUrl": "https://avatars.githubusercontent.com/u/73457237?v=4",
           "htmlUrl": "https://github.com/TSK-Glofy"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "r0inttjcby48tly602p410vo",
-      "path": "app/docs/community/dev-tips/Katex/Seb1.mdx",
+      "path": "content/docs/community/dev-tips/Katex/Seb1.mdx",
       "contributorStats": {
-        "73457237": 2
+        "73457237": 2,
+        "114939201": 1
       },
       "contributors": [
         {
@@ -1069,8 +1083,8 @@
         },
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -1079,9 +1093,10 @@
     },
     {
       "docId": "khcrztruqdku9fntd3dwzvwe",
-      "path": "app/docs/community/dev-tips/Katex/Seb2.mdx",
+      "path": "content/docs/community/dev-tips/Katex/Seb2.mdx",
       "contributorStats": {
-        "73457237": 2
+        "73457237": 2,
+        "114939201": 1
       },
       "contributors": [
         {
@@ -1094,8 +1109,8 @@
         },
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -1104,9 +1119,10 @@
     },
     {
       "docId": "e6udpzrorhvgeeda6xpy1e0s",
-      "path": "app/docs/community/dev-tips/picturecdn.mdx",
+      "path": "content/docs/community/dev-tips/picturecdn.mdx",
       "contributorStats": {
-        "59130571": 2
+        "59130571": 2,
+        "114939201": 1
       },
       "contributors": [
         {
@@ -1119,8 +1135,8 @@
         },
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -1129,11 +1145,20 @@
     },
     {
       "docId": "i0xmpskau105p83vq35wnxls",
-      "path": "app/docs/community/dev-tips/raspberry-guide.md",
+      "path": "content/docs/community/dev-tips/raspberry-guide.md",
       "contributorStats": {
-        "73457237": 1
+        "73457237": 1,
+        "114939201": 1
       },
       "contributors": [
+        {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
         {
           "githubId": "73457237",
           "contributions": 1,
@@ -1141,22 +1166,15 @@
           "login": "TSK-Glofy",
           "avatarUrl": "https://avatars.githubusercontent.com/u/73457237?v=4",
           "htmlUrl": "https://github.com/TSK-Glofy"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "sfzt30mtx0jsuv6esnpm3w8y",
-      "path": "app/docs/community/index.mdx",
+      "path": "content/docs/community/index.mdx",
       "contributorStats": {
         "73457237": 2,
+        "114939201": 1,
         "194795025": 1
       },
       "contributors": [
@@ -1169,27 +1187,28 @@
           "htmlUrl": "https://github.com/TSK-Glofy"
         },
         {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
+        {
           "githubId": "194795025",
           "contributions": 1,
           "lastContributedAt": "2025-09-21T11:31:51.000Z",
           "login": "LynPtl",
           "avatarUrl": "https://avatars.githubusercontent.com/u/194795025?v=4",
           "htmlUrl": "https://github.com/LynPtl"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "m37j6a24hb9mlrm0g6jfcxop",
-      "path": "app/docs/community/language/pte-intro.md",
+      "path": "content/docs/community/language/pte-intro.md",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 4
       },
       "contributors": [
@@ -1203,8 +1222,8 @@
         },
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -1213,8 +1232,9 @@
     },
     {
       "docId": "jgyg6bp0nceyrxirz5qw3zsv",
-      "path": "app/docs/community/life/unsw-student-benefit.md",
+      "path": "content/docs/community/life/unsw-student-benefit.md",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 2
       },
       "contributors": [
@@ -1228,8 +1248,8 @@
         },
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -1238,13 +1258,22 @@
     },
     {
       "docId": "q8d1j9bii2ve2p7pp4xtok79",
-      "path": "app/docs/community/mental-health/burnout-guide.mdx",
+      "path": "content/docs/community/mental-health/burnout-guide.mdx",
       "contributorStats": {
         "73457237": 1,
         "95595902": 1,
+        "114939201": 1,
         "147322547": 1
       },
       "contributors": [
+        {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
         {
           "githubId": "147322547",
           "contributions": 1,
@@ -1268,24 +1297,25 @@
           "login": "TSK-Glofy",
           "avatarUrl": "https://avatars.githubusercontent.com/u/73457237?v=4",
           "htmlUrl": "https://github.com/TSK-Glofy"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "rxyvvumcvfl2oh3hky8urkfn",
-      "path": "app/docs/community/mental-health/index.mdx",
+      "path": "content/docs/community/mental-health/index.mdx",
       "contributorStats": {
-        "73457237": 1
+        "73457237": 1,
+        "114939201": 1
       },
       "contributors": [
+        {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
         {
           "githubId": "73457237",
           "contributions": 1,
@@ -1293,24 +1323,25 @@
           "login": "TSK-Glofy",
           "avatarUrl": "https://avatars.githubusercontent.com/u/73457237?v=4",
           "htmlUrl": "https://github.com/TSK-Glofy"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "boo70qqm8nos8b0q9h7zjrki",
-      "path": "app/docs/community/papers/leworldmodel.md",
+      "path": "content/docs/community/papers/leworldmodel.en.md",
       "contributorStats": {
+        "114939201": 1,
         "128119791": 1
       },
       "contributors": [
+        {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
         {
           "githubId": "128119791",
           "contributions": 1,
@@ -1318,26 +1349,27 @@
           "login": "CeitherNSW",
           "avatarUrl": "https://avatars.githubusercontent.com/u/128119791?v=4",
           "htmlUrl": "https://github.com/CeitherNSW"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "l6eepr5ctjgrhdgupy3twr1t",
-      "path": "app/docs/community/papers/prompt-repetition-improves-non-reasoning-llms.md",
+      "path": "content/docs/community/papers/prompt-repetition-improves-non-reasoning-llms.en.md",
       "contributorStats": {
+        "114939201": 1,
         "128119791": 1,
         "138507318": 1,
         "163523387": 1
       },
       "contributors": [
+        {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
         {
           "githubId": "138507318",
           "contributions": 1,
@@ -1361,24 +1393,25 @@
           "login": "CeitherNSW",
           "avatarUrl": "https://avatars.githubusercontent.com/u/128119791?v=4",
           "htmlUrl": "https://github.com/CeitherNSW"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "mgb41edhi9cz1kxzae074an0",
-      "path": "app/docs/community/tools/index.md",
+      "path": "content/docs/community/tools/index.md",
       "contributorStats": {
-        "7187663": 1
+        "7187663": 1,
+        "114939201": 1
       },
       "contributors": [
+        {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
         {
           "githubId": "7187663",
           "contributions": 1,
@@ -1386,24 +1419,25 @@
           "login": "Crokily",
           "avatarUrl": "https://avatars.githubusercontent.com/u/7187663?v=4",
           "htmlUrl": "https://github.com/Crokily"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "eej2awin6irhbdgcy8vvs3xb",
-      "path": "app/docs/community/tools/perplexity-comet.md",
+      "path": "content/docs/community/tools/perplexity-comet.md",
       "contributorStats": {
-        "7187663": 1
+        "7187663": 1,
+        "114939201": 1
       },
       "contributors": [
+        {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
         {
           "githubId": "7187663",
           "contributions": 1,
@@ -1411,24 +1445,25 @@
           "login": "Crokily",
           "avatarUrl": "https://avatars.githubusercontent.com/u/7187663?v=4",
           "htmlUrl": "https://github.com/Crokily"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "mhyoknm6vj8jmp186oli5f5c",
-      "path": "app/docs/community/tools/swanlab.mdx",
+      "path": "content/docs/community/tools/swanlab.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 1
       },
       "contributors": [
+        {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
         {
           "githubId": "163523387",
           "contributions": 1,
@@ -1436,24 +1471,25 @@
           "login": "Mira190",
           "avatarUrl": "https://avatars.githubusercontent.com/u/163523387?v=4",
           "htmlUrl": "https://github.com/Mira190"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "ue27z7z95yzw3lhhfj7nit1c",
-      "path": "app/docs/learn/ai/agents-todo/agent-ecosystem.mdx",
+      "path": "content/docs/learn/ai/agents-todo/agent-ecosystem.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 1
       },
       "contributors": [
+        {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
         {
           "githubId": "163523387",
           "contributions": 1,
@@ -1461,21 +1497,14 @@
           "login": "Mira190",
           "avatarUrl": "https://avatars.githubusercontent.com/u/163523387?v=4",
           "htmlUrl": "https://github.com/Mira190"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "eo5rwumxkh7twfdvlp5po9rc",
-      "path": "app/docs/learn/ai/agents-todo/cs294-194-196/index.mdx",
+      "path": "content/docs/learn/ai/agents-todo/cs294-194-196/index.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 2
       },
       "contributors": [
@@ -1489,8 +1518,8 @@
         },
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -1499,8 +1528,9 @@
     },
     {
       "docId": "v8m8kdjzzx7uhiz69r5m3m9o",
-      "path": "app/docs/learn/ai/ai-math-basics/calculus-optimization/index.mdx",
+      "path": "content/docs/learn/ai/ai-math-basics/calculus-optimization/index.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 2
       },
       "contributors": [
@@ -1514,8 +1544,8 @@
         },
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -1524,8 +1554,9 @@
     },
     {
       "docId": "gpoh50befguf7zgsetzkvbi3",
-      "path": "app/docs/learn/ai/ai-math-basics/information-theory/index.mdx",
+      "path": "content/docs/learn/ai/ai-math-basics/information-theory/index.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 2
       },
       "contributors": [
@@ -1539,8 +1570,8 @@
         },
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -1549,8 +1580,9 @@
     },
     {
       "docId": "l1kvojw2gvggxflrmzc7j7sm",
-      "path": "app/docs/learn/ai/ai-math-basics/linear-algebra/index.mdx",
+      "path": "content/docs/learn/ai/ai-math-basics/linear-algebra/index.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 2
       },
       "contributors": [
@@ -1564,8 +1596,8 @@
         },
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -1574,8 +1606,9 @@
     },
     {
       "docId": "ba5lqs2zg1jqc30qzw3osm9v",
-      "path": "app/docs/learn/ai/ai-math-basics/linear-algebra/resources/index.mdx",
+      "path": "content/docs/learn/ai/ai-math-basics/linear-algebra/resources/index.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 2
       },
       "contributors": [
@@ -1589,8 +1622,8 @@
         },
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -1599,9 +1632,10 @@
     },
     {
       "docId": "kzi6k1yg1sehlxidnxdsf59a",
-      "path": "app/docs/learn/ai/ai-math-basics/math_books.md",
+      "path": "content/docs/learn/ai/ai-math-basics/math_books.md",
       "contributorStats": {
-        "84211946": 3
+        "84211946": 3,
+        "114939201": 1
       },
       "contributors": [
         {
@@ -1614,8 +1648,8 @@
         },
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -1624,11 +1658,20 @@
     },
     {
       "docId": "vcfer8dvlt80se4kmbnshx7x",
-      "path": "app/docs/learn/ai/ai-math-basics/math-foundations.mdx",
+      "path": "content/docs/learn/ai/ai-math-basics/math-foundations.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 1
       },
       "contributors": [
+        {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
         {
           "githubId": "163523387",
           "contributions": 1,
@@ -1636,21 +1679,14 @@
           "login": "Mira190",
           "avatarUrl": "https://avatars.githubusercontent.com/u/163523387?v=4",
           "htmlUrl": "https://github.com/Mira190"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "ebgss2sa91drisxswsh6iu8x",
-      "path": "app/docs/learn/ai/ai-math-basics/numerical-analysis/index.mdx",
+      "path": "content/docs/learn/ai/ai-math-basics/numerical-analysis/index.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 2
       },
       "contributors": [
@@ -1664,8 +1700,8 @@
         },
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -1674,8 +1710,9 @@
     },
     {
       "docId": "d5fya0gd1w8vblv8qeqgnqtu",
-      "path": "app/docs/learn/ai/ai-math-basics/probability-statistics/index.mdx",
+      "path": "content/docs/learn/ai/ai-math-basics/probability-statistics/index.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 2
       },
       "contributors": [
@@ -1689,8 +1726,8 @@
         },
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -1699,8 +1736,9 @@
     },
     {
       "docId": "q7kagbrpnek7b89axvssn4bo",
-      "path": "app/docs/learn/ai/ai-math-basics/probability-statistics/resources/index.mdx",
+      "path": "content/docs/learn/ai/ai-math-basics/probability-statistics/resources/index.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 2
       },
       "contributors": [
@@ -1714,8 +1752,8 @@
         },
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -1724,11 +1762,20 @@
     },
     {
       "docId": "d73h3kyjnzytk1y2nizulyr6",
-      "path": "app/docs/learn/ai/compute-platforms/compute-platforms-handbook.mdx",
+      "path": "content/docs/learn/ai/compute-platforms/compute-platforms-handbook.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 1
       },
       "contributors": [
+        {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
         {
           "githubId": "163523387",
           "contributions": 1,
@@ -1736,26 +1783,20 @@
           "login": "Mira190",
           "avatarUrl": "https://avatars.githubusercontent.com/u/163523387?v=4",
           "htmlUrl": "https://github.com/Mira190"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "ns7q5ehuje6oiua7as6rtnyf",
-      "path": "app/docs/learn/ai/compute-platforms/model-compuational-resource-demand.md",
-      "contributorStats": {},
+      "path": "content/docs/learn/ai/compute-platforms/model-compuational-resource-demand.md",
+      "contributorStats": {
+        "114939201": 1
+      },
       "contributors": [
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -1764,8 +1805,9 @@
     },
     {
       "docId": "egpawb1yui58yprrsgxn9qj2",
-      "path": "app/docs/learn/ai/foundation-models/datasets/index.mdx",
+      "path": "content/docs/learn/ai/foundation-models/datasets/index.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 2
       },
       "contributors": [
@@ -1779,8 +1821,8 @@
         },
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -1789,8 +1831,9 @@
     },
     {
       "docId": "z157s85hnz1y37tr28y2a8h2",
-      "path": "app/docs/learn/ai/foundation-models/deploy-infer/index.mdx",
+      "path": "content/docs/learn/ai/foundation-models/deploy-infer/index.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 2
       },
       "contributors": [
@@ -1804,8 +1847,8 @@
         },
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -1814,8 +1857,9 @@
     },
     {
       "docId": "lndxpf7luoeqwwde4in23xr1",
-      "path": "app/docs/learn/ai/foundation-models/evaluation/index.mdx",
+      "path": "content/docs/learn/ai/foundation-models/evaluation/index.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 2
       },
       "contributors": [
@@ -1829,8 +1873,8 @@
         },
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -1839,8 +1883,9 @@
     },
     {
       "docId": "l5nes88zd54y6ao64ufkylz2",
-      "path": "app/docs/learn/ai/foundation-models/finetune/index.mdx",
+      "path": "content/docs/learn/ai/foundation-models/finetune/index.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 2
       },
       "contributors": [
@@ -1854,8 +1899,8 @@
         },
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -1864,8 +1909,9 @@
     },
     {
       "docId": "i88bna4sg5pr4ekhg32drv2i",
-      "path": "app/docs/learn/ai/foundation-models/foundation-models-lifecycle.mdx",
+      "path": "content/docs/learn/ai/foundation-models/foundation-models-lifecycle.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 2
       },
       "contributors": [
@@ -1879,8 +1925,8 @@
         },
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -1889,8 +1935,9 @@
     },
     {
       "docId": "h7s6nm7h5oqnhhdq9m1mgwwo",
-      "path": "app/docs/learn/ai/foundation-models/qkv-interview/index.mdx",
+      "path": "content/docs/learn/ai/foundation-models/qkv-interview/index.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 2
       },
       "contributors": [
@@ -1904,8 +1951,8 @@
         },
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -1914,9 +1961,10 @@
     },
     {
       "docId": "wdqqrepoy43jiieyyjmaekk1",
-      "path": "app/docs/learn/ai/foundation-models/rag/context-engineering-intro.md",
+      "path": "content/docs/learn/ai/foundation-models/rag/context-engineering-intro.md",
       "contributorStats": {
         "7187663": 2,
+        "114939201": 1,
         "166212872": 1
       },
       "contributors": [
@@ -1929,30 +1977,39 @@
           "htmlUrl": "https://github.com/Crokily"
         },
         {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
+        {
           "githubId": "166212872",
           "contributions": 1,
           "lastContributedAt": "2025-10-03T11:36:59.000Z",
           "login": "yoyofancy",
           "avatarUrl": "https://avatars.githubusercontent.com/u/166212872?v=4",
           "htmlUrl": "https://github.com/yoyofancy"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "eyd32o3ebd5q69hfbb2enxqi",
-      "path": "app/docs/learn/ai/foundation-models/rag/embedding.mdx",
+      "path": "content/docs/learn/ai/foundation-models/rag/embedding.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 1
       },
       "contributors": [
+        {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
         {
           "githubId": "163523387",
           "contributions": 1,
@@ -1960,22 +2017,15 @@
           "login": "Mira190",
           "avatarUrl": "https://avatars.githubusercontent.com/u/163523387?v=4",
           "htmlUrl": "https://github.com/Mira190"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "zywri1bs64awfi9utfjy14ll",
-      "path": "app/docs/learn/ai/foundation-models/rag/rag.mdx",
+      "path": "content/docs/learn/ai/foundation-models/rag/rag.mdx",
       "contributorStats": {
         "59130571": 1,
+        "114939201": 1,
         "163523387": 1,
         "166212872": 2
       },
@@ -1987,6 +2037,14 @@
           "login": "yoyofancy",
           "avatarUrl": "https://avatars.githubusercontent.com/u/166212872?v=4",
           "htmlUrl": "https://github.com/yoyofancy"
+        },
+        {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
         },
         {
           "githubId": "163523387",
@@ -2003,21 +2061,14 @@
           "login": "RavenCaffeine",
           "avatarUrl": "https://avatars.githubusercontent.com/u/59130571?v=4",
           "htmlUrl": "https://github.com/RavenCaffeine"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "jgz0nl0cbd4frj2dg98mdv0x",
-      "path": "app/docs/learn/ai/foundation-models/training/index.mdx",
+      "path": "content/docs/learn/ai/foundation-models/training/index.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 2
       },
       "contributors": [
@@ -2031,8 +2082,8 @@
         },
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -2041,11 +2092,20 @@
     },
     {
       "docId": "nor5ktairygnt4dorqbddo9n",
-      "path": "app/docs/learn/ai/generative-todo/generative-models-plan.mdx",
+      "path": "content/docs/learn/ai/generative-todo/generative-models-plan.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 1
       },
       "contributors": [
+        {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
         {
           "githubId": "163523387",
           "contributions": 1,
@@ -2053,21 +2113,14 @@
           "login": "Mira190",
           "avatarUrl": "https://avatars.githubusercontent.com/u/163523387?v=4",
           "htmlUrl": "https://github.com/Mira190"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "ix9azldhgm46j4i1xzgnd26r",
-      "path": "app/docs/learn/ai/index.mdx",
+      "path": "content/docs/learn/ai/index.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 4
       },
       "contributors": [
@@ -2081,8 +2134,8 @@
         },
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -2091,8 +2144,9 @@
     },
     {
       "docId": "h53uwefhlykt9ietsx9x0vtn",
-      "path": "app/docs/learn/ai/Introduction-of-Multi-agents-system/introduction_of_multi-agents_system.md",
+      "path": "content/docs/learn/ai/Introduction-of-Multi-agents-system/introduction_of_multi-agents_system.md",
       "contributorStats": {
+        "114939201": 1,
         "123258594": 2,
         "166212872": 2
       },
@@ -2115,8 +2169,8 @@
         },
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -2125,8 +2179,9 @@
     },
     {
       "docId": "xboc8qj2128aivvt0goo1wow",
-      "path": "app/docs/learn/ai/llm-basics/courses/index.mdx",
+      "path": "content/docs/learn/ai/llm-basics/courses/index.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 2
       },
       "contributors": [
@@ -2140,8 +2195,8 @@
         },
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -2150,8 +2205,9 @@
     },
     {
       "docId": "nwt5322vw4q6sz8ho8qynv28",
-      "path": "app/docs/learn/ai/llm-basics/cuda/index.mdx",
+      "path": "content/docs/learn/ai/llm-basics/cuda/index.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 2
       },
       "contributors": [
@@ -2165,8 +2221,8 @@
         },
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -2175,8 +2231,9 @@
     },
     {
       "docId": "dqg4iqz7hgyq38cqz3tg9tlf",
-      "path": "app/docs/learn/ai/llm-basics/deep-learning/d2l/index.mdx",
+      "path": "content/docs/learn/ai/llm-basics/deep-learning/d2l/index.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 2
       },
       "contributors": [
@@ -2190,8 +2247,8 @@
         },
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -2200,8 +2257,9 @@
     },
     {
       "docId": "vdclex41huib10ccsqw9u76k",
-      "path": "app/docs/learn/ai/llm-basics/deep-learning/index.mdx",
+      "path": "content/docs/learn/ai/llm-basics/deep-learning/index.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 2
       },
       "contributors": [
@@ -2215,8 +2273,8 @@
         },
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -2225,8 +2283,9 @@
     },
     {
       "docId": "lodydcd211esraq1r55ze9ey",
-      "path": "app/docs/learn/ai/llm-basics/deep-learning/misc/index.mdx",
+      "path": "content/docs/learn/ai/llm-basics/deep-learning/misc/index.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 2,
         "166212872": 1
       },
@@ -2240,27 +2299,28 @@
           "htmlUrl": "https://github.com/Mira190"
         },
         {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
+        {
           "githubId": "166212872",
           "contributions": 1,
           "lastContributedAt": "2025-10-02T00:42:19.000Z",
           "login": "yoyofancy",
           "avatarUrl": "https://avatars.githubusercontent.com/u/166212872?v=4",
           "htmlUrl": "https://github.com/yoyofancy"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "nrelvvfzq0gma7pqfx9fkfxt",
-      "path": "app/docs/learn/ai/llm-basics/deep-learning/nlp/index.mdx",
+      "path": "content/docs/learn/ai/llm-basics/deep-learning/nlp/index.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 2
       },
       "contributors": [
@@ -2274,8 +2334,8 @@
         },
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -2284,8 +2344,9 @@
     },
     {
       "docId": "xnl2yzrb4x748zhhfe26ragt",
-      "path": "app/docs/learn/ai/llm-basics/embeddings/index.mdx",
+      "path": "content/docs/learn/ai/llm-basics/embeddings/index.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 2
       },
       "contributors": [
@@ -2299,8 +2360,8 @@
         },
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -2309,8 +2370,9 @@
     },
     {
       "docId": "jq6323xynmyapm5vgncmyymh",
-      "path": "app/docs/learn/ai/llm-basics/embeddings/qwen3-embedding/index.mdx",
+      "path": "content/docs/learn/ai/llm-basics/embeddings/qwen3-embedding/index.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 2
       },
       "contributors": [
@@ -2324,8 +2386,8 @@
         },
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -2334,11 +2396,20 @@
     },
     {
       "docId": "h8awdow89uicdy4kx9iimlta",
-      "path": "app/docs/learn/ai/llm-basics/llm-foundations.mdx",
+      "path": "content/docs/learn/ai/llm-basics/llm-foundations.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 1
       },
       "contributors": [
+        {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
         {
           "githubId": "163523387",
           "contributions": 1,
@@ -2346,21 +2417,14 @@
           "login": "Mira190",
           "avatarUrl": "https://avatars.githubusercontent.com/u/163523387?v=4",
           "htmlUrl": "https://github.com/Mira190"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "psc0xf6oa1m7g8s9wfwiojkf",
-      "path": "app/docs/learn/ai/llm-basics/pytorch/index.mdx",
+      "path": "content/docs/learn/ai/llm-basics/pytorch/index.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 3
       },
       "contributors": [
@@ -2374,8 +2438,8 @@
         },
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -2384,8 +2448,9 @@
     },
     {
       "docId": "k1owc5kfw3vihc5hnmysqttl",
-      "path": "app/docs/learn/ai/llm-basics/transformer/ai-by-hand/index.mdx",
+      "path": "content/docs/learn/ai/llm-basics/transformer/ai-by-hand/index.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 2
       },
       "contributors": [
@@ -2399,8 +2464,8 @@
         },
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -2409,8 +2474,9 @@
     },
     {
       "docId": "lsokl8ofmo7msxlqyvihbhz5",
-      "path": "app/docs/learn/ai/llm-basics/transformer/index.mdx",
+      "path": "content/docs/learn/ai/llm-basics/transformer/index.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 2
       },
       "contributors": [
@@ -2424,8 +2490,8 @@
         },
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -2434,11 +2500,20 @@
     },
     {
       "docId": "r68izu11bkrkk6st194kwk80",
-      "path": "app/docs/learn/ai/methodology/research-methodology.mdx",
+      "path": "content/docs/learn/ai/methodology/research-methodology.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 1
       },
       "contributors": [
+        {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
         {
           "githubId": "163523387",
           "contributions": 1,
@@ -2446,21 +2521,14 @@
           "login": "Mira190",
           "avatarUrl": "https://avatars.githubusercontent.com/u/163523387?v=4",
           "htmlUrl": "https://github.com/Mira190"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "uguqyqpacxyj5irjickbt8n9",
-      "path": "app/docs/learn/ai/misc-tools/learning-toolkit.mdx",
+      "path": "content/docs/learn/ai/misc-tools/learning-toolkit.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 3
       },
       "contributors": [
@@ -2474,8 +2542,8 @@
         },
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -2484,11 +2552,20 @@
     },
     {
       "docId": "x3xs4hk0mc7lxlgbgskti5qk",
-      "path": "app/docs/learn/ai/model-datasets-platforms/platform-and-datasets.mdx",
+      "path": "content/docs/learn/ai/model-datasets-platforms/platform-and-datasets.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 1
       },
       "contributors": [
+        {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
         {
           "githubId": "163523387",
           "contributions": 1,
@@ -2496,26 +2573,20 @@
           "login": "Mira190",
           "avatarUrl": "https://avatars.githubusercontent.com/u/163523387?v=4",
           "htmlUrl": "https://github.com/Mira190"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "qftv72k0kzwiz8ddksbcl2aw",
-      "path": "app/docs/learn/ai/MoE/MOE-intro.md",
-      "contributorStats": {},
+      "path": "content/docs/learn/ai/MoE/MOE-intro.md",
+      "contributorStats": {
+        "114939201": 1
+      },
       "contributors": [
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -2524,12 +2595,21 @@
     },
     {
       "docId": "db3qwg25h6l0bh8f2sdabdqc",
-      "path": "app/docs/learn/ai/MoE/moe-update.md",
+      "path": "content/docs/learn/ai/MoE/moe-update.md",
       "contributorStats": {
         "76551253": 1,
+        "114939201": 1,
         "163523387": 1
       },
       "contributors": [
+        {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
         {
           "githubId": "163523387",
           "contributions": 1,
@@ -2545,21 +2625,14 @@
           "login": "840691168",
           "avatarUrl": "https://avatars.githubusercontent.com/u/76551253?v=4",
           "htmlUrl": "https://github.com/840691168"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "qaezsrj15sudk796r5otne36",
-      "path": "app/docs/learn/ai/Multi-agents-system-on-Code-Translation/code-translation-intro.mdx",
+      "path": "content/docs/learn/ai/Multi-agents-system-on-Code-Translation/code-translation-intro.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 2
       },
       "contributors": [
@@ -2573,8 +2646,8 @@
         },
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -2583,8 +2656,9 @@
     },
     {
       "docId": "pmrtokz6393ywte5zqeskpm0",
-      "path": "app/docs/learn/ai/multimodal/courses/index.mdx",
+      "path": "content/docs/learn/ai/multimodal/courses/index.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 2
       },
       "contributors": [
@@ -2598,8 +2672,8 @@
         },
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -2608,8 +2682,9 @@
     },
     {
       "docId": "pffzdgytknyhaywar8uzyf2e",
-      "path": "app/docs/learn/ai/multimodal/llava/index.mdx",
+      "path": "content/docs/learn/ai/multimodal/llava/index.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 2
       },
       "contributors": [
@@ -2623,8 +2698,8 @@
         },
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -2633,8 +2708,9 @@
     },
     {
       "docId": "gc6tdzkkwxn5t90nw69fibl6",
-      "path": "app/docs/learn/ai/multimodal/mllm/index.mdx",
+      "path": "content/docs/learn/ai/multimodal/mllm/index.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 3
       },
       "contributors": [
@@ -2648,8 +2724,8 @@
         },
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -2658,8 +2734,9 @@
     },
     {
       "docId": "zte4s8s8ls4cs25mfrzyepfl",
-      "path": "app/docs/learn/ai/multimodal/multimodal-overview.mdx",
+      "path": "content/docs/learn/ai/multimodal/multimodal-overview.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 2
       },
       "contributors": [
@@ -2673,8 +2750,8 @@
         },
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -2683,8 +2760,9 @@
     },
     {
       "docId": "ybczrbgxo5t4pl0erce7qz6w",
-      "path": "app/docs/learn/ai/multimodal/qwenvl/index.mdx",
+      "path": "content/docs/learn/ai/multimodal/qwenvl/index.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 2
       },
       "contributors": [
@@ -2698,8 +2776,8 @@
         },
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -2708,12 +2786,21 @@
     },
     {
       "docId": "pqplmwaj5o5aszydqo1drzrj",
-      "path": "app/docs/learn/ai/multimodal/RQVAE/index.mdx",
+      "path": "content/docs/learn/ai/multimodal/RQVAE/index.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 1,
         "188854497": 1
       },
       "contributors": [
+        {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
         {
           "githubId": "163523387",
           "contributions": 1,
@@ -2729,25 +2816,26 @@
           "login": "0dysseus13",
           "avatarUrl": "https://avatars.githubusercontent.com/u/188854497?v=4",
           "htmlUrl": "https://github.com/0dysseus13"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "k6cgwcc28l9iap5s5oyjbjwo",
-      "path": "app/docs/learn/ai/multimodal/VAE/index.mdx",
+      "path": "content/docs/learn/ai/multimodal/VAE/index.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 1,
         "188854497": 1
       },
       "contributors": [
+        {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
         {
           "githubId": "163523387",
           "contributions": 1,
@@ -2763,21 +2851,14 @@
           "login": "0dysseus13",
           "avatarUrl": "https://avatars.githubusercontent.com/u/188854497?v=4",
           "htmlUrl": "https://github.com/0dysseus13"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "ssrhm03fw9sbogk78dmy92ml",
-      "path": "app/docs/learn/ai/multimodal/video-mm-todo/index.mdx",
+      "path": "content/docs/learn/ai/multimodal/video-mm-todo/index.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 3
       },
       "contributors": [
@@ -2791,8 +2872,8 @@
         },
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -2801,8 +2882,9 @@
     },
     {
       "docId": "xd3q72ubqzlesz8x4gewhi5r",
-      "path": "app/docs/learn/ai/multimodal/vit/index.mdx",
+      "path": "content/docs/learn/ai/multimodal/vit/index.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 2
       },
       "contributors": [
@@ -2816,8 +2898,8 @@
         },
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -2826,12 +2908,21 @@
     },
     {
       "docId": "otfiks0uz3aue1bdvlyqmj3e",
-      "path": "app/docs/learn/ai/multimodal/VQVAE/index.mdx",
+      "path": "content/docs/learn/ai/multimodal/VQVAE/index.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 1,
         "188854497": 1
       },
       "contributors": [
+        {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
         {
           "githubId": "163523387",
           "contributions": 1,
@@ -2847,24 +2938,25 @@
           "login": "0dysseus13",
           "avatarUrl": "https://avatars.githubusercontent.com/u/188854497?v=4",
           "htmlUrl": "https://github.com/0dysseus13"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "as876rdhtmpnyyeclxt226s1",
-      "path": "app/docs/learn/ai/recommender-systems/recommender-roadmap.mdx",
+      "path": "content/docs/learn/ai/recommender-systems/recommender-roadmap.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 1
       },
       "contributors": [
+        {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
         {
           "githubId": "163523387",
           "contributions": 1,
@@ -2872,24 +2964,25 @@
           "login": "Mira190",
           "avatarUrl": "https://avatars.githubusercontent.com/u/163523387?v=4",
           "htmlUrl": "https://github.com/Mira190"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "hajz43iblku13mmevia8zrhv",
-      "path": "app/docs/learn/ai/recommender-systems/wangshusen_recommend_crossing.mdx",
+      "path": "content/docs/learn/ai/recommender-systems/wangshusen_recommend_crossing.mdx",
       "contributorStats": {
+        "114939201": 1,
         "188854497": 1
       },
       "contributors": [
+        {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
         {
           "githubId": "188854497",
           "contributions": 1,
@@ -2897,25 +2990,26 @@
           "login": "0dysseus13",
           "avatarUrl": "https://avatars.githubusercontent.com/u/188854497?v=4",
           "htmlUrl": "https://github.com/0dysseus13"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "bvccoatft6y7bph83oivdcfe",
-      "path": "app/docs/learn/ai/recommender-systems/wangshusen_recommend_note_coldstart.mdx",
+      "path": "content/docs/learn/ai/recommender-systems/wangshusen_recommend_note_coldstart.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 1,
         "188854497": 1
       },
       "contributors": [
+        {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
         {
           "githubId": "163523387",
           "contributions": 1,
@@ -2931,25 +3025,26 @@
           "login": "0dysseus13",
           "avatarUrl": "https://avatars.githubusercontent.com/u/188854497?v=4",
           "htmlUrl": "https://github.com/0dysseus13"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "qmy3p4vc45ek61ce4n62fpxy",
-      "path": "app/docs/learn/ai/recommender-systems/wangshusen_recommend_note_improvement.mdx",
+      "path": "content/docs/learn/ai/recommender-systems/wangshusen_recommend_note_improvement.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 1,
         "188854497": 1
       },
       "contributors": [
+        {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
         {
           "githubId": "163523387",
           "contributions": 1,
@@ -2965,25 +3060,26 @@
           "login": "0dysseus13",
           "avatarUrl": "https://avatars.githubusercontent.com/u/188854497?v=4",
           "htmlUrl": "https://github.com/0dysseus13"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "vjwogf9afghpbvi71e4dfsgj",
-      "path": "app/docs/learn/ai/recommender-systems/wangshusen_recommend_note_rank.mdx",
+      "path": "content/docs/learn/ai/recommender-systems/wangshusen_recommend_note_rank.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 1,
         "188854497": 1
       },
       "contributors": [
+        {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
         {
           "githubId": "163523387",
           "contributions": 1,
@@ -2999,24 +3095,25 @@
           "login": "0dysseus13",
           "avatarUrl": "https://avatars.githubusercontent.com/u/188854497?v=4",
           "htmlUrl": "https://github.com/0dysseus13"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "ol03smbujgwztho45ycj52ah",
-      "path": "app/docs/learn/ai/recommender-systems/wangshusen_recommend_note_rerank.mdx",
+      "path": "content/docs/learn/ai/recommender-systems/wangshusen_recommend_note_rerank.mdx",
       "contributorStats": {
+        "114939201": 1,
         "188854497": 1
       },
       "contributors": [
+        {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
         {
           "githubId": "188854497",
           "contributions": 1,
@@ -3024,21 +3121,14 @@
           "login": "0dysseus13",
           "avatarUrl": "https://avatars.githubusercontent.com/u/188854497?v=4",
           "htmlUrl": "https://github.com/0dysseus13"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "c3a4nmid9plytif5ameigj7d",
-      "path": "app/docs/learn/ai/recommender-systems/wangshusen_recommend_note/wangshusen_recommend_note_retrieval.mdx",
+      "path": "content/docs/learn/ai/recommender-systems/wangshusen_recommend_note/wangshusen_recommend_note_retrieval.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 1,
         "188854497": 2
       },
@@ -3052,27 +3142,28 @@
           "htmlUrl": "https://github.com/0dysseus13"
         },
         {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
+        {
           "githubId": "163523387",
           "contributions": 1,
           "lastContributedAt": "2025-09-24T23:29:45.000Z",
           "login": "Mira190",
           "avatarUrl": "https://avatars.githubusercontent.com/u/163523387?v=4",
           "htmlUrl": "https://github.com/Mira190"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "zf8zk108oqbsg56xjyqb5txk",
-      "path": "app/docs/learn/ai/reinforcement-learning/ppo.md",
+      "path": "content/docs/learn/ai/reinforcement-learning/ppo.md",
       "contributorStats": {
+        "114939201": 1,
         "206296353": 4
       },
       "contributors": [
@@ -3086,8 +3177,8 @@
         },
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -3096,11 +3187,20 @@
     },
     {
       "docId": "s4fuhmdf6hj49jx1l7k87d4p",
-      "path": "app/docs/learn/ai/reinforcement-learning/reinforcement-learning-overview.mdx",
+      "path": "content/docs/learn/ai/reinforcement-learning/reinforcement-learning-overview.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 1
       },
       "contributors": [
+        {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
         {
           "githubId": "163523387",
           "contributions": 1,
@@ -3108,24 +3208,25 @@
           "login": "Mira190",
           "avatarUrl": "https://avatars.githubusercontent.com/u/163523387?v=4",
           "htmlUrl": "https://github.com/Mira190"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "totx4pej5lhyt1nl4anwhakj",
-      "path": "app/docs/learn/cs/cpp-backend/easy-compile/1-cpp-libs.md",
+      "path": "content/docs/learn/cs/cpp-backend/easy-compile/1-cpp-libs.md",
       "contributorStats": {
-        "100033202": 1
+        "100033202": 1,
+        "114939201": 1
       },
       "contributors": [
+        {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
         {
           "githubId": "100033202",
           "contributions": 1,
@@ -3133,24 +3234,25 @@
           "login": "duang3457",
           "avatarUrl": "https://avatars.githubusercontent.com/u/100033202?v=4",
           "htmlUrl": "https://github.com/duang3457"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "kyu85av71b4n07hbdycbhvj9",
-      "path": "app/docs/learn/cs/cpp-backend/easy-compile/2-base-gcc.md",
+      "path": "content/docs/learn/cs/cpp-backend/easy-compile/2-base-gcc.md",
       "contributorStats": {
-        "100033202": 1
+        "100033202": 1,
+        "114939201": 1
       },
       "contributors": [
+        {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
         {
           "githubId": "100033202",
           "contributions": 1,
@@ -3158,25 +3260,26 @@
           "login": "duang3457",
           "avatarUrl": "https://avatars.githubusercontent.com/u/100033202?v=4",
           "htmlUrl": "https://github.com/duang3457"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "g6wucmr69lamd9xyxm7uunnd",
-      "path": "app/docs/learn/cs/cpp-backend/easy-compile/3-make.md",
+      "path": "content/docs/learn/cs/cpp-backend/easy-compile/3-make.md",
       "contributorStats": {
         "7187663": 1,
-        "100033202": 1
+        "100033202": 1,
+        "114939201": 1
       },
       "contributors": [
+        {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
         {
           "githubId": "7187663",
           "contributions": 1,
@@ -3192,24 +3295,25 @@
           "login": "duang3457",
           "avatarUrl": "https://avatars.githubusercontent.com/u/100033202?v=4",
           "htmlUrl": "https://github.com/duang3457"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "xk44lx4q1gpcm1uqk8nnbg7q",
-      "path": "app/docs/learn/cs/cpp-backend/easy-compile/4-cmake.md",
+      "path": "content/docs/learn/cs/cpp-backend/easy-compile/4-cmake.md",
       "contributorStats": {
-        "100033202": 1
+        "100033202": 1,
+        "114939201": 1
       },
       "contributors": [
+        {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
         {
           "githubId": "100033202",
           "contributions": 1,
@@ -3217,24 +3321,25 @@
           "login": "duang3457",
           "avatarUrl": "https://avatars.githubusercontent.com/u/100033202?v=4",
           "htmlUrl": "https://github.com/duang3457"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "gtqamuq3tftmvzstbunkgbo5",
-      "path": "app/docs/learn/cs/cpp-backend/easy-compile/5-vcpkg.md",
+      "path": "content/docs/learn/cs/cpp-backend/easy-compile/5-vcpkg.md",
       "contributorStats": {
-        "100033202": 1
+        "100033202": 1,
+        "114939201": 1
       },
       "contributors": [
+        {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
         {
           "githubId": "100033202",
           "contributions": 1,
@@ -3242,24 +3347,25 @@
           "login": "duang3457",
           "avatarUrl": "https://avatars.githubusercontent.com/u/100033202?v=4",
           "htmlUrl": "https://github.com/duang3457"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "mnjkrtrs7xk3fq538eqreuge",
-      "path": "app/docs/learn/cs/cpp-backend/handwritten-pool-components/1-handwritten-threadpool.md",
+      "path": "content/docs/learn/cs/cpp-backend/handwritten-pool-components/1-handwritten-threadpool.md",
       "contributorStats": {
-        "100033202": 1
+        "100033202": 1,
+        "114939201": 1
       },
       "contributors": [
+        {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
         {
           "githubId": "100033202",
           "contributions": 1,
@@ -3267,24 +3373,25 @@
           "login": "duang3457",
           "avatarUrl": "https://avatars.githubusercontent.com/u/100033202?v=4",
           "htmlUrl": "https://github.com/duang3457"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "xgxqqvglxyauoeh8eye7lzu6",
-      "path": "app/docs/learn/cs/cpp-backend/handwritten-pool-components/2-handwritten-mempool1.md",
+      "path": "content/docs/learn/cs/cpp-backend/handwritten-pool-components/2-handwritten-mempool1.md",
       "contributorStats": {
-        "100033202": 1
+        "100033202": 1,
+        "114939201": 1
       },
       "contributors": [
+        {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
         {
           "githubId": "100033202",
           "contributions": 1,
@@ -3292,24 +3399,25 @@
           "login": "duang3457",
           "avatarUrl": "https://avatars.githubusercontent.com/u/100033202?v=4",
           "htmlUrl": "https://github.com/duang3457"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "q8290wmhyofuiskzn1ph63ta",
-      "path": "app/docs/learn/cs/cpp-backend/mempool-simple.mdx",
+      "path": "content/docs/learn/cs/cpp-backend/mempool-simple.mdx",
       "contributorStats": {
-        "100033202": 1
+        "100033202": 1,
+        "114939201": 1
       },
       "contributors": [
+        {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
         {
           "githubId": "100033202",
           "contributions": 1,
@@ -3317,24 +3425,25 @@
           "login": "duang3457",
           "avatarUrl": "https://avatars.githubusercontent.com/u/100033202?v=4",
           "htmlUrl": "https://github.com/duang3457"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "gmpls10e2dz0bbizotvhglc8",
-      "path": "app/docs/learn/cs/data-structures/array/01-static-array.mdx",
+      "path": "content/docs/learn/cs/data-structures/array/01-static-array.en.mdx",
       "contributorStats": {
-        "7187663": 1
+        "7187663": 1,
+        "114939201": 1
       },
       "contributors": [
+        {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
         {
           "githubId": "7187663",
           "contributions": 1,
@@ -3342,24 +3451,25 @@
           "login": "Crokily",
           "avatarUrl": "https://avatars.githubusercontent.com/u/7187663?v=4",
           "htmlUrl": "https://github.com/Crokily"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "nuojcaq1s6r5nggul0uq3r3j",
-      "path": "app/docs/learn/cs/data-structures/array/02-dynamic-array.mdx",
+      "path": "content/docs/learn/cs/data-structures/array/02-dynamic-array.en.mdx",
       "contributorStats": {
-        "7187663": 1
+        "7187663": 1,
+        "114939201": 1
       },
       "contributors": [
+        {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
         {
           "githubId": "7187663",
           "contributions": 1,
@@ -3367,24 +3477,25 @@
           "login": "Crokily",
           "avatarUrl": "https://avatars.githubusercontent.com/u/7187663?v=4",
           "htmlUrl": "https://github.com/Crokily"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "ai7cmwf4irjaobqf7uokj3b4",
-      "path": "app/docs/learn/cs/data-structures/array/index.mdx",
+      "path": "content/docs/learn/cs/data-structures/array/index.en.mdx",
       "contributorStats": {
-        "7187663": 1
+        "7187663": 1,
+        "114939201": 1
       },
       "contributors": [
+        {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
         {
           "githubId": "7187663",
           "contributions": 1,
@@ -3392,24 +3503,25 @@
           "login": "Crokily",
           "avatarUrl": "https://avatars.githubusercontent.com/u/7187663?v=4",
           "htmlUrl": "https://github.com/Crokily"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "vti0bt2qlnr681msbk6igznc",
-      "path": "app/docs/learn/cs/data-structures/index.mdx",
+      "path": "content/docs/learn/cs/data-structures/index.en.mdx",
       "contributorStats": {
-        "7187663": 1
+        "7187663": 1,
+        "114939201": 1
       },
       "contributors": [
+        {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
         {
           "githubId": "7187663",
           "contributions": 1,
@@ -3417,24 +3529,25 @@
           "login": "Crokily",
           "avatarUrl": "https://avatars.githubusercontent.com/u/7187663?v=4",
           "htmlUrl": "https://github.com/Crokily"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "gkjk6stzpb44n9lv8u2ij7xx",
-      "path": "app/docs/learn/cs/data-structures/linked-list/01-singly-linked-list.mdx",
+      "path": "content/docs/learn/cs/data-structures/linked-list/01-singly-linked-list.en.mdx",
       "contributorStats": {
-        "7187663": 1
+        "7187663": 1,
+        "114939201": 1
       },
       "contributors": [
+        {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
         {
           "githubId": "7187663",
           "contributions": 1,
@@ -3442,24 +3555,25 @@
           "login": "Crokily",
           "avatarUrl": "https://avatars.githubusercontent.com/u/7187663?v=4",
           "htmlUrl": "https://github.com/Crokily"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "lt9yrqt0ksl2liabq9ocw0z4",
-      "path": "app/docs/learn/cs/data-structures/linked-list/index.mdx",
+      "path": "content/docs/learn/cs/data-structures/linked-list/index.en.mdx",
       "contributorStats": {
-        "7187663": 1
+        "7187663": 1,
+        "114939201": 1
       },
       "contributors": [
+        {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
         {
           "githubId": "7187663",
           "contributions": 1,
@@ -3467,25 +3581,26 @@
           "login": "Crokily",
           "avatarUrl": "https://avatars.githubusercontent.com/u/7187663?v=4",
           "htmlUrl": "https://github.com/Crokily"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "uzoqs57kwc4tfut4wvgnbjhf",
-      "path": "app/docs/learn/cs/frontend/frontend-learning/index.mdx",
+      "path": "content/docs/learn/cs/frontend/frontend-learning/index.mdx",
       "contributorStats": {
         "104760545": 1,
+        "114939201": 1,
         "163523387": 1
       },
       "contributors": [
+        {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
         {
           "githubId": "163523387",
           "contributions": 1,
@@ -3501,25 +3616,26 @@
           "login": "KAGA11",
           "avatarUrl": "https://avatars.githubusercontent.com/u/104760545?v=4",
           "htmlUrl": "https://github.com/KAGA11"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "y3xkz4kituc738jwsojo7cml",
-      "path": "app/docs/learn/cs/frontend/index.mdx",
+      "path": "content/docs/learn/cs/frontend/index.mdx",
       "contributorStats": {
         "104760545": 1,
+        "114939201": 1,
         "163523387": 1
       },
       "contributors": [
+        {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
         {
           "githubId": "163523387",
           "contributions": 1,
@@ -3535,22 +3651,15 @@
           "login": "KAGA11",
           "avatarUrl": "https://avatars.githubusercontent.com/u/104760545?v=4",
           "htmlUrl": "https://github.com/KAGA11"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     },
     {
       "docId": "ksjj9shalh6hqezx6t6am5vw",
-      "path": "app/docs/learn/cs/index.mdx",
+      "path": "content/docs/learn/cs/index.mdx",
       "contributorStats": {
-        "7187663": 3
+        "7187663": 3,
+        "114939201": 1
       },
       "contributors": [
         {
@@ -3563,8 +3672,8 @@
         },
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -3573,13 +3682,15 @@
     },
     {
       "docId": "lrn0001index2026041800000001",
-      "path": "app/docs/learn/index.mdx",
-      "contributorStats": {},
+      "path": "content/docs/learn/index.mdx",
+      "contributorStats": {
+        "114939201": 1
+      },
       "contributors": [
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -3588,8 +3699,9 @@
     },
     {
       "docId": "bkxwg1m9p9rnm8062wsm020w",
-      "path": "app/docs/projects/ai-town.mdx",
+      "path": "content/docs/projects/ai-town.mdx",
       "contributorStats": {
+        "114939201": 1,
         "163523387": 3
       },
       "contributors": [
@@ -3603,8 +3715,8 @@
         },
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -3613,13 +3725,15 @@
     },
     {
       "docId": "prj0001index2026041800000001",
-      "path": "app/docs/projects/index.mdx",
-      "contributorStats": {},
+      "path": "content/docs/projects/index.mdx",
+      "contributorStats": {
+        "114939201": 1
+      },
       "contributors": [
         {
           "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
           "login": "longsizhuo",
           "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
           "htmlUrl": "https://github.com/longsizhuo"
@@ -3628,8 +3742,9 @@
     },
     {
       "docId": "ifwz8sqxqsgjrafa79pycrcm",
-      "path": "app/docs/projects/multimodal-rl.mdx",
+      "path": "content/docs/projects/multimodal-rl.mdx",
       "contributorStats": {
+        "114939201": 1,
         "150361711": 1,
         "163523387": 3
       },
@@ -3643,20 +3758,20 @@
           "htmlUrl": "https://github.com/Mira190"
         },
         {
+          "githubId": "114939201",
+          "contributions": 1,
+          "lastContributedAt": "2026-05-06T14:33:51.000Z",
+          "login": "longsizhuo",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
+          "htmlUrl": "https://github.com/longsizhuo"
+        },
+        {
           "githubId": "150361711",
           "contributions": 1,
           "lastContributedAt": "2025-10-17T10:15:30.000Z",
           "login": "mojitote",
           "avatarUrl": "https://avatars.githubusercontent.com/u/150361711?v=4",
           "htmlUrl": "https://github.com/mojitote"
-        },
-        {
-          "githubId": "114939201",
-          "contributions": 0,
-          "lastContributedAt": "2026-04-18T17:04:44.000Z",
-          "login": "longsizhuo",
-          "avatarUrl": "https://avatars.githubusercontent.com/u/114939201?v=4",
-          "htmlUrl": "https://github.com/longsizhuo"
         }
       ]
     }


### PR DESCRIPTION
## 背景

i18n PR (#330) 让 docs 全量 SSG，剩首页（占 30 天 Vercel Fluid CPU ~25%）仍 ƒ Dynamic。原因：

```tsx
// app/[locale]/page.tsx
export default async function HomePage(...) {
  const homepageEvents = await fetchHomepageEvents();  // ← server fetch
  ...
}
```

``Hero`` 内的 `HotDocsPreview` 和 `ActivityTicker` 也是 async server component，server fetch backend 同样阻挡 SSG。

## 改造

### 1. 新建两条 ISR 代理 API

| Route | revalidate | 用途 |
|---|---|---|
| `/api/public/homepage-events` | 5min | 首页活动数据（FloatWindow / ActivityTicker） |
| `/api/public/top-docs` | 5min | 本周最热文档（HotDocsPreview） |

server-side 调后端，浏览器调自家代理（同源无 CORS，BACKEND_URL 不暴露），revalidate 让 Next.js Data Cache + 浏览器 Cache-Control 双保险，最多每 5min 一次后端调用。

### 2. 三个组件改 client

- `ActivityTicker` async server → client + useEffect fetch
- `HotDocsPreview` async server → client；翻译从 `getTranslations` 改 `useTranslations`（client hook）；fetch 期间显示 Skeleton
- `FloatWindow` 从 props 接 event 改为自取

### 3. page.tsx 纯静态

- 删 `await fetchHomepageEvents()` + 删 prop 传递
- 加 `export const dynamic = 'force-static'` + `setRequestLocale` 双保险

## build 验证

```
├ ● /[locale]                                ← 从 ƒ 变 ●
│ ├ /zh
│ └ /en
├ ○ /api/public/homepage-events  5m  1y
├ ○ /api/public/top-docs         5m  1y
```

322 → 361 prerendered routes（多了 /zh、/en、+ 两条 ISR API）。

## 预期收益

- Vercel Fluid CPU 月用量：~3h51m → ~0.5-1h（仅 admin / events / feed / u/[username] 等数据动态路由产生）
- 首页 TTFB：之前 1.7-2s（前后端串联）→ 静态 HTML 直接 serve
- LCP / Core Web Vitals 改善

## 副作用

- 首屏 ActivityTicker / HotDocsPreview 不立即出现，等 hydrate 后 fetch 显示
- ticker 不是 LCP 元素，HotDocsPreview 有 Skeleton 占位避免 CLS，可接受

## Test plan

- [ ] preview 部署 `/zh` 看 FloatWindow 1-2s 内显示
- [ ] HotDocsPreview Skeleton → 真实数据切换无 layout shift
- [ ] ActivityTicker 在 hydrate 后出现
- [ ] Vercel Observability 一周后看 `/[locale]` 的 invocation 数应该接近 0
- [ ] 直接访问 `/api/public/homepage-events` 返回正常 JSON
