### PR TITLE
feat(growth): UTM 跟踪 doc 分享 + turbopack root 锁定

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <a href="https://involutionhell.com">
+  <a href="https://involutionhell.com/?utm_source=github&utm_medium=readme&utm_campaign=logo">
     <picture>
       <!-- Dark mode logo -->
       <source media="(prefers-color-scheme: dark)" srcset="./public/logo/logoInDark.svg">
@@ -21,7 +21,7 @@
   <img alt="Next.js" src="https://img.shields.io/badge/Next.js-000000?style=for-the-badge&logo=nextdotjs&logoColor=white" />
   <img alt="Vercel" src="https://img.shields.io/badge/Vercel-000000?style=for-the-badge&logo=vercel&logoColor=white" />
   <a href="https://github.com/InvolutionHell/involutionhell/blob/main/LICENSE">
-  <a href="https://involutionhell.com">
+  <a href="https://involutionhell.com/?utm_source=github&utm_medium=readme&utm_campaign=badge">
     <img src="https://img.shields.io/badge/Website-involutionhell.com-blue?style=for-the-badge" alt="Official Website">
   </a>
 </p>

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <a href="https://involutionhell.com">
+  <a href="https://involutionhell.com/?utm_source=github&utm_medium=readme&utm_campaign=logo">
     <picture>
       <!-- Dark mode logo -->
       <source media="(prefers-color-scheme: dark)" srcset="./public/logo/logoInDark.svg">
@@ -21,7 +21,7 @@
   <img alt="Next.js" src="https://img.shields.io/badge/Next.js-000000?style=for-the-badge&logo=nextdotjs&logoColor=white" />
   <img alt="Vercel" src="https://img.shields.io/badge/Vercel-000000?style=for-the-badge&logo=vercel&logoColor=white" />
   <a href="https://github.com/InvolutionHell/involutionhell/blob/main/LICENSE">
-  <a href="https://involutionhell.com">
+  <a href="https://involutionhell.com/?utm_source=github&utm_medium=readme&utm_campaign=badge">
     <img src="https://img.shields.io/badge/Website-involutionhell.com-blue?style=for-the-badge" alt="Official Website">
   </a>
 </p>

--- a/app/components/DocShareButton.tsx
+++ b/app/components/DocShareButton.tsx
@@ -20,7 +20,12 @@ export function DocShareButton() {
   }, []);
 
   const handleCopy = async () => {
-    const url = window.location.href;
+    // 用户点"复制链接"必然是要发到外面（DC/微信/X）
+    // 给链接打上 UTM，回流时能在 GA Source 维度看到 doc_share，区别于 (direct)
+    const target = new URL(window.location.href);
+    target.searchParams.set("utm_source", "doc_share");
+    target.searchParams.set("utm_medium", "user_share");
+    const url = target.toString();
     try {
       await navigator.clipboard.writeText(url);
       setCopied(true);

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,7 +1,17 @@
 ﻿// next.config.mjs
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { createMDX } from "fumadocs-mdx/next";
 import createNextIntlPlugin from "next-intl/plugin";
 import { withSentryConfig } from "@sentry/nextjs";
+
+// Next.js 16 detects multi-lockfile environments by searching upward for
+// pnpm-lock.yaml / package-lock.json / yarn.lock. 当父目录意外有 lockfile
+// 时（如开发服务器上 /home/ubuntu/package-lock.json），Next 会把 workspace
+// root 推到上层，turbopack 跟着到错的目录解析 node_modules，
+// 触发 "Can't resolve 'tailwindcss'" 之类报错。
+// 显式锁定到 frontend 自己目录，turbopack + outputFileTracing 双保险。
+const projectRoot = path.dirname(fileURLToPath(import.meta.url));
 
 /**
  * IMPORTANT: remarkImage 配置已移至 source.config.ts 统一管理
@@ -22,6 +32,12 @@ const withNextIntl = createNextIntlPlugin("./i18n/request.ts");
 /** @type {import('next').NextConfig} */
 const config = {
   reactStrictMode: true,
+  // 强制锁定 turbopack 和 SSR file tracing 的根目录到 frontend/ 自己，
+  // 避免上层意外 lockfile 把 root 推错（详见文件顶部注释）。
+  turbopack: {
+    root: projectRoot,
+  },
+  outputFileTracingRoot: projectRoot,
   /**
    * docs 目录整理产生的 URL 变化 → 301 重定向。
    *


### PR DESCRIPTION
## 背景

i18n PR (#330) 之前 `feat/utm-tracking` 分支上有几个零散改动，PR 开始时 stash 出来避免和 i18n 大重构混在一起。本 PR 恢复这些工作。

## 内容

### 1. UTM 跟踪 GitHub README 入站流量

`README.md` / `README.en.md` 的 logo 和 badge 链接：

```diff
- href="https://involutionhell.com"
+ href="https://involutionhell.com/?utm_source=github&utm_medium=readme&utm_campaign=logo"
- href="https://involutionhell.com"   (badge)
+ href="https://involutionhell.com/?utm_source=github&utm_medium=readme&utm_campaign=badge"
```

GA Source 维度可以分清"从 GitHub readme logo 进站" vs "从 badge 进站"。

### 2. UTM 跟踪用户主动分享 doc 链接

`DocShareButton.tsx` 用户点"复制链接"时：

```diff
- const url = window.location.href;
+ const target = new URL(window.location.href);
+ target.searchParams.set("utm_source", "doc_share");
+ target.searchParams.set("utm_medium", "user_share");
+ const url = target.toString();
```

用户复制到 Discord / 微信 / X 之后，回流时 GA 能看到 `doc_share` source，区别于 `(direct)/(none)`，能定量看出"用户主动分享"对站点流量的贡献。

### 3. turbopack root 显式锁定（次要工程改动）

`next.config.mjs` 加：

```js
turbopack: { root: projectRoot },
outputFileTracingRoot: projectRoot,
```

Next.js 16 默认会向上搜 lockfile 推 workspace root。开发机 `/home/ubuntu/package-lock.json` 这类上层 lockfile 会把 root 推到上层，turbopack 解析 node_modules 错位 → `Can't resolve 'tailwindcss'` 之类报错。锁死 root 防 dev 翻车。

## Test plan

- [ ] preview 部署 README 链接点开后 URL 上能看到 utm_*
- [ ] 任意 doc 页点"复制链接"粘贴出来带 utm 参数
- [ ] dev server 起得来（验证 turbopack root 锁定不破其它东西）
- [ ] GA 一周后 Acquisition 报告能看到 `github / readme` 和 `doc_share / user_share` source
