### PR TITLE
🔥 hotfix(proxy): matcher 排除 oauth/auth/analytics，修复登录 404

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -83,7 +83,11 @@ export function proxy(req: NextRequest) {
 export const config = {
   // Match all pathnames except for
   // - api / trpc：API 路由不进 i18n（无 UI，纯 fetch）
+  // - auth / oauth / analytics：next.config rewrites 直通后端的路径
+  //   （登录 / OAuth / 埋点）。被 next-intl 加了 locale 前缀后，
+  //   rewrite source（/oauth/:path*）不匹配带 locale 的版本（/en/oauth/...），
+  //   落到 [locale]/oauth/... 404。所以必须排除掉，让请求直接走 rewrite。
   // - _next / _vercel：Next.js 内部
   // - .*\..*：任何带 . 的路径（静态资源 / sitemap.xml / robots.txt 等）
-  matcher: "/((?!api|trpc|_next|_vercel|.*\\..*).*)",
+  matcher: "/((?!api|trpc|auth|oauth|analytics|_next|_vercel|.*\\..*).*)",
 };


### PR DESCRIPTION
## 🔥 紧急 hotfix：登录炸了

**复现**：访问 `https://involutionhell.com/en/oauth/render/github` → 404，**所有用户无法登录**。

## 根因

i18n PR (#330) 让 next-intl middleware 接管全站 locale routing。但 `proxy.ts` 的 matcher 只排除了 `api/trpc/_next/_vercel/静态资源`，**漏掉了 `next.config.mjs` 里 rewrite 到后端的非 `/api/` 路径**：

| 路径 | 用途 |
|---|---|
| `/auth/:path*` | NextAuth-like (`/auth/me`、`/auth/logout`) |
| `/oauth/:path*` | OAuth 跳转入口（登录入口） ⚠️ |
| `/analytics/:path*` | 埋点 |

请求流：

```
用户访问 /oauth/render/github
  ↓
next-intl middleware 308 redirect → /en/oauth/render/github
  （按 cookie / Accept-Language 加 locale 前缀）
  ↓
next.config rewrite source 是 /oauth/:path* 不带 locale，不匹配
  ↓
落到 app/[locale]/oauth/... 但这个 page 不存在
  ↓
404 → 登录炸
```

## 修

`proxy.ts` matcher 加排除：

```diff
- matcher: "/((?!api|trpc|_next|_vercel|.*\\..*).*)",
+ matcher: "/((?!api|trpc|auth|oauth|analytics|_next|_vercel|.*\\..*).*)",
```

排除后这 3 类路径不被 next-intl 拦截，直接走 next.config rewrite 到后端。

## Test plan

- [ ] preview 部署 `curl -I https://<preview>/oauth/render/github` 应该是 302（后端 OAuth redirect 到 GitHub），**不是** 308 redirect 到 `/en/oauth/...`
- [ ] preview `/auth/me` 返回后端响应（而不是 next-intl redirect）
- [ ] 登录流走通：点 SignIn → 跳 GitHub → 回调 `/api/auth/callback/github` → 落地

## 后续

加个**集成测试**保证 i18n routing 不再误吃 backend rewrite 路径，避免类似问题再发生。但这次优先 hotfix。
