### PR TITLE
fix(prebuild): escape-angles idempotency for HTML tags with attributes

### DIFF
--- a/scripts/escape-angles.mjs
+++ b/scripts/escape-angles.mjs
@@ -2,17 +2,44 @@
  * @description 转义尖括号脚本
  * @author Siz Long
  * @date 2025-09-27
+ *
+ * 2026-05 更新：修幂等性 bug
+ *   旧 negative lookahead `(?![A-Za-z/][A-Za-z0-9:_-]*\s*\/?>)` 只接受
+ *   <div> / </div> / <br /> 这种**无属性**的标签，把 `<img src="..." />`、
+ *   `<a href="...">` 这种**带属性的合法 HTML** 误判为"可疑尖括号"并 escape。
+ *   导致：每次 build 都把 leetcode markdown 注释里的 `<img>` 转 `&lt;img&gt;`，
+ *   working tree 永久脏。Backfill workflow（要求 git status 干净）反复被阻断。
+ *
+ *   修：lookahead 加属性段 `([ \t][^<>]*)?`，让 `<tagname attr="...">` 也被
+ *   识别为正常 HTML 不 escape。
+ *
+ * 极简策略：
+ * 1) 跳过 fenced code / inline code（保留原样）
+ * 2) 仅在普通文本行内转义形如 <数字开头...> 或 <单词里含逗号/空格/数学符号...> 的片段
+ * 3) 不动像 <Component> / <div> / <img src="..." />（含属性）这类"正常标签"
  */
 import { promises as fs } from "node:fs";
 import fg from "fast-glob";
 
-/**
- * 极简策略：
- * 1) 跳过 fenced code / inline code（保留原样）
- * 2) 仅在普通文本行内转义形如 <数字开头...> 或 <单词里含逗号/空格/数学符号...> 的片段
- * 3) 不动像 <Component> / <div> 这类“正常标签/组件名”的片段
- */
 const files = await fg(["content/docs/**/*.md"], { dot: false });
+
+/**
+ * 正常 HTML/JSX 标签匹配模式（用于 negative lookahead）：
+ *   - 可选 `/` 表示闭合标签 (</div>)
+ *   - 标签名首字母为字母，后跟字母/数字/冒号/下划线/连字符
+ *   - 可选属性段：空格后跟任意非尖括号字符（[^<>] 防 ReDoS）
+ *   - 可选 `/` 表示自闭合 (<br />)
+ *   - `>` 收尾
+ *
+ * 接受样例（lookahead 命中，不 escape）：
+ *   <div>           </div>         <br />
+ *   <img src="..." />              <a href="x" title="y">
+ *   <Component prop="val" />
+ *
+ * 不接受样例（lookahead miss，进 escape 分支）：
+ *   <8>             <1,2,3>        <x, y>         <not a tag>
+ */
+const VALID_TAG_LOOKAHEAD = /\/?[A-Za-z][A-Za-z0-9:_-]*([ \t][^<>]*)?\s*\/?>/;
 
 for (const file of files) {
   let src = await fs.readFile(file, "utf8");
@@ -30,14 +57,14 @@ for (const file of files) {
     return `__CODE_BLOCK_${blocks.length - 1}__`;
   });
 
-  // 在普通文本里做“可疑尖括号”的转义：
+  // 在普通文本里做"可疑尖括号"的转义：
   //  - <\d...>  如 <8>、<1,2,3>
   //  - <[^\s/>][^>]*[,;+\-*/= ]+[^>]*>  含明显非标签符号的
   src = src
     .replace(/<\d[^>]*>/g, (m) =>
       m.replaceAll("<", "&lt;").replaceAll(">", "&gt;"),
     )
-    .replace(/<(?![A-Za-z/][A-Za-z0-9:_-]*\s*\/?>)[^>]*>/g, (m) =>
+    .replace(new RegExp(`<(?!${VALID_TAG_LOOKAHEAD.source})[^>]*>`, "g"), (m) =>
       m.replaceAll("<", "&lt;").replaceAll(">", "&gt;"),
     );
 


### PR DESCRIPTION
## Summary

Prebuild 的 `scripts/escape-angles.mjs` 每次跑都把 leetcode markdown 注释里的 `<img src="..." />` 改成 `&lt;img src="..." /&gt;`，导致：

- `pnpm build` 每次都让 git working tree 脏
- 服务器上 Backfill workflow（要求 git status 干净）反复 fail
- 之前每个 PR 都要 git restore 这种产物文件再跑

## Root cause

Negative lookahead 只接受**无属性**的合法标签：

```js
/<(?![A-Za-z/][A-Za-z0-9:_-]*\s*\/?>)[^>]*>/
```

- 命中（不 escape）：`<div>` / `</div>` / `<br />`
- **误判（被 escape）**：`<img src="..." />` / `<a href="...">` / `<Component prop="val" />`

## Fix

Lookahead 加属性段：

```js
/\/?[A-Za-z][A-Za-z0-9:_-]*([ \t][^<>]*)?\s*\/?>/
```

- `[ \t][^<>]*` — 空格后跟任意非尖括号字符（属性段）
- `[^<>]` 防止 ReDoS 嵌套量词（CodeQL 2026-05 已经在另一个文件提过同类）

## 验证

跑两次 escape-angles 后 working tree 不变（之前每次跑都脏）。仍 escape：

- ✅ `<8>` `<1,2,3>` （数字开头）
- ✅ `<x, y>` （含逗号的"数学符号"型）

不再误 escape：

- ✅ `<img src="..." />`
- ✅ `<a href="..." title="...">`
- ✅ `<Component prop="val" />`

## Test plan

- [ ] CI: build / content-check 跑过
- [ ] Backfill workflow 之后 main push 时不再卡在脏树
- [ ] 用户本地跑 `pnpm build` 后 git status 干净