### PR TITLE
Use PageData type for page data assertions

### DIFF
--- a/app/docs/layout.tsx
+++ b/app/docs/layout.tsx
@@ -7,6 +7,7 @@ import type { PageTree } from "fumadocs-core/server";
 import { CopyTracking } from "@/app/components/CopyTracking";
 import { DocsPageViewTracker } from "@/app/components/DocsPageViewTracker";
 import { cookies } from "next/headers";
+import { type PageData } from "@/app/types/doc";
 
 type Locale = "zh" | "en";
 type SourcePage = ReturnType<typeof source.getPages>[number];
@@ -77,7 +78,7 @@ function chooseVariant(variants: SourcePage[], locale: Locale): SourcePage {
   const originalMatching = variants.find((p) => {
     const { suffix } = stripLocaleSuffix(p.slugs);
     if (suffix !== null) return false;
-    const lang = (p.data as { lang?: string }).lang;
+    const lang = (p.data as PageData).lang;
     return lang === locale;
   });
   if (originalMatching) return originalMatching;

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -127,8 +127,8 @@ function buildDocsEntry(page: SourcePage): MetadataRoute.Sitemap[number] {
  * @returns {Date | undefined} 解析后的 Date 对象，如果找不到或无效则返回 undefined。
  */
 function extractDateFromPage(page: SourcePage): Date | undefined {
-  // (FIX) 使用我们定义的 PageData 类型，而不是 'as' 一个匿名对象
-  const data = (page.data ?? {}) as PageData;
+  // 使用我们定义的 PageData 类型
+  const data = page.data as PageData;
 
   const candidates: DateLike[] = [
     data?.updatedAt,
@@ -183,8 +183,8 @@ function sanitizeSlugPath(slugs: string[]): string {
  * @returns {boolean} 如果是草稿或隐藏，返回 true。
  */
 function isDraftOrHidden(page: SourcePage): boolean {
-  // [BUILD 修复] 使用我们定义的 PageData 类型来代替 'any'
-  const d = (page.data ?? {}) as PageData;
+  // 使用我们定义的 PageData 类型
+  const d = page.data as PageData;
 
   // 检查顶层或 'frontmatter' 嵌套下的 'draft' 或 'hidden' 标志
   return !!(


### PR DESCRIPTION
This PR refactors the codebase to use the centralized `PageData` type for all `page.data` assertions. 

Key changes:
- In `app/sitemap.ts`:
  - Cleaned up `extractDateFromPage` to use `page.data as PageData` directly.
  - Cleaned up `isDraftOrHidden` to use `page.data as PageData` directly.
  - Removed stale "(FIX)" and "[BUILD 修复]" comments.
- In `app/docs/layout.tsx`:
  - Imported `PageData` from `@/app/types/doc`.
  - Replaced the anonymous cast `(p.data as { lang?: string })` with `(p.data as PageData)` in the `chooseVariant` function.

These changes ensure better type safety and consistency, following the project's preference for using the centralized documentation types.

---
*PR created automatically by Jules for task [13987742699219027133](https://jules.google.com/task/13987742699219027133) started by @longsizhuo*