### PR TITLE
fix(header): 右上角日期客户端实时刷新，避免 SSG 冻结 build 时刻

### DIFF
--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -12,7 +12,7 @@ import { LiveDate } from "./LiveDate";
 
 export async function Header() {
   const t = await getTranslations("header");
-  const editionTimestampMs = Date.now();
+  const editionTimestampMs = new Date().getTime();
   return (
     <header className="fixed top-0 w-full z-50 bg-[var(--background)] border-b border-[var(--foreground)] py-2 transition-colors duration-300">
       <div className="container mx-auto px-6">

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -8,26 +8,18 @@ import { Github as GithubIcon } from "./icons/Github";
 import { AuthNav } from "./AuthNav";
 import { BrandMark } from "./BrandMark";
 import { LiveEditionLabel } from "./LiveEditionLabel";
+import { LiveDate } from "./LiveDate";
 
 export async function Header() {
   const t = await getTranslations("header");
-  const now = new Date();
-  const editionTimestampMs = now.getTime();
-  const formattedDate = now.toLocaleDateString("en-US", {
-    month: "long",
-    day: "numeric",
-    year: "numeric",
-    timeZone: "Australia/Sydney",
-  });
+  const editionTimestampMs = Date.now();
   return (
     <header className="fixed top-0 w-full z-50 bg-[var(--background)] border-b border-[var(--foreground)] py-2 transition-colors duration-300">
       <div className="container mx-auto px-6">
         <div className="flex items-center justify-between border-b border-[var(--foreground)] pb-2 mb-2 transition-colors duration-300">
           <LiveEditionLabel initialTimestamp={editionTimestampMs} />
           <BrandMark priority />
-          <div className="font-mono text-[10px] uppercase tracking-widest text-neutral-500">
-            {formattedDate}
-          </div>
+          <LiveDate initialTimestamp={editionTimestampMs} />
         </div>
 
         <div className="flex items-center justify-end md:justify-between h-10">

--- a/app/components/LiveDate.tsx
+++ b/app/components/LiveDate.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+type LiveDateProps = {
+  // milliseconds since epoch
+  initialTimestamp: number;
+};
+
+// 固定时区（悉尼）保证服务端/客户端首帧一致，避免 hydration mismatch；
+// 挂载后每秒刷新，避免 SSG/ISR 把 build 时刻的日期冻住。
+const TIMEZONE = "Australia/Sydney";
+
+function formatDate(ms: number) {
+  return new Date(ms).toLocaleDateString("en-US", {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+    timeZone: TIMEZONE,
+  });
+}
+
+export function LiveDate({ initialTimestamp }: LiveDateProps) {
+  const [formattedDate, setFormattedDate] = useState(() =>
+    formatDate(initialTimestamp),
+  );
+
+  useEffect(() => {
+    const update = () => setFormattedDate(formatDate(Date.now()));
+    update();
+    const intervalId = setInterval(update, 1000);
+    return () => clearInterval(intervalId);
+  }, []);
+
+  return (
+    <div className="font-mono text-[10px] uppercase tracking-widest text-neutral-500">
+      {formattedDate}
+    </div>
+  );
+}


### PR DESCRIPTION
## 问题

线上 https://involutionhell.com/zh 右上角日期长期停留在陈旧日期（如 `May 25, 2026`），不会随时间更新。

## 根因

`Header.tsx` 是 server component，右侧日期用 `new Date().toLocaleDateString(...)` 在渲染时计算。首页走 SSG/ISR，该日期被**冻结在 build 时刻**，运行时不会更新。左侧 `LiveEditionLabel` 之所以正常，是因为它是 client component，靠 `setInterval` 每秒刷新。

## 修复

新增 client component `LiveDate`，沿用 `LiveEditionLabel` 已验证的模式：

- 首帧用 server 传入的 `initialTimestamp` 渲染，保证 hydration 一致
- 挂载后固定悉尼时区（`Australia/Sydney`）+ 每秒刷新，避免再被 build 时刻冻住

Header 改为传入时间戳并渲染 `<LiveDate />`，移除 server 端的 `formattedDate` 计算。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012hTtDXTtmMFKYJ7CYhBD1h)_