### PR TITLE
fix(rank): Document History 列表加滚动，修内容溢出 (#358)

### DIFF
--- a/app/components/rank/ContributorRow.tsx
+++ b/app/components/rank/ContributorRow.tsx
@@ -67,7 +67,7 @@ export function ContributorRow({
 
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 bg-black/60 z-50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
-        <Dialog.Content className="fixed left-[50%] outline-none top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border-2 border-[var(--foreground)] bg-[var(--background)] p-6 sm:p-8 shadow-[8px_8px_0px_0px_var(--foreground)] duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] max-h-[85vh] flex col">
+        <Dialog.Content className="fixed left-[50%] outline-none top-[50%] z-50 flex flex-col w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border-2 border-[var(--foreground)] bg-[var(--background)] p-6 sm:p-8 shadow-[8px_8px_0px_0px_var(--foreground)] duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] max-h-[85vh]">
           {/* 弹窗核心内容：左侧头像，右侧个人基础信息 */}
           <div className="flex justify-between items-start border-b-4 border-[var(--foreground)] pb-6 mb-4 shrink-0 relative">
             <div className="flex gap-5 md:gap-6 items-start w-full pr-12">
@@ -164,7 +164,7 @@ export function ContributorRow({
           </div>
 
           {/* 文章贡献历史列表展示 */}
-          <div className="overflow-y-auto pr-2 flex-grow min-h-[150px] relative">
+          <div className="overflow-y-auto pr-2 flex-grow min-h-0 relative">
             <h4 className="font-mono text-xs uppercase tracking-widest mb-3 text-[#111111]/70 dark:text-neutral-400 flex items-center gap-2">
               Document History
             </h4>

--- a/app/components/rank/ContributorRow.tsx
+++ b/app/components/rank/ContributorRow.tsx
@@ -193,7 +193,7 @@ export function ContributorRow({
                       data-umami-event-doc={doc.title}
                       data-umami-event-user={user.name}
                     >
-                      <span className="font-mono text-sm text-[#111111] dark:text-neutral-200 group-hover/link:underline decoration-2 decoration-[#CC0000] underline-offset-4 truncate pr-4">
+                      <span className="font-mono text-sm text-[#111111] dark:text-neutral-200 group-hover/link:underline decoration-2 decoration-[#CC0000] underline-offset-4 truncate pr-4 min-w-0">
                         {doc.title}
                       </span>
                       <ExternalLink className="h-4 w-4 text-[#111111]/50 dark:text-neutral-400 group-hover/link:text-[#CC0000] transition-colors shrink-0" />


### PR DESCRIPTION
## 问题
Rank 页贡献者弹窗的 **Document History** 列表没有滚动，文档多时内容溢出弹窗（#358）。

## 根因
`ContributorRow.tsx` 的 `Dialog.Content` className 同时写了 `grid` 和 `flex col`：
- `grid` 与 `flex` 都设 `display`，Tailwind 级联里 `grid` 胜出 → flex 列容器从未生效；
- `col` 不是合法 Tailwind class（no-op）；
- 即便 flex 生效，滚动子容器的 `min-h-[150px]` 也会阻止收缩到滚动。

## 修复
- `Dialog.Content`：`grid … flex col` → `flex flex-col`
- 滚动子容器：`min-h-[150px]` → `min-h-0`（flex 子项默认 `min-height:auto` 阻止收缩，`min-h-0` 才能让 `overflow-y-auto` 生效）

这是 flex 滚动的标准写法。空状态由 `flex-grow` 撑开，不受影响。

## 验证
- 逐层 trace flex 链：`Dialog.Content`(flex-col, max-h-[85vh]) → header(`shrink-0`) → 滚动区(`flex-grow min-h-0 overflow-y-auto`)。
- 对抗式 review 复核为 canonical scroll pattern，旧标记确为三重 bug。
- pre-commit 全量测试 52 passed。

Closes #358

🤖 Generated with [Claude Code](https://claude.com/claude-code)