### PR TITLE
fix(rank): 热门文档榜链接补 locale 前缀，修 /content/ 死链

### DIFF
--- a/app/components/HotDocsPreview.tsx
+++ b/app/components/HotDocsPreview.tsx
@@ -2,7 +2,8 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
+import { topDocHref } from "@/lib/top-doc-href";
 
 interface TopDocDto {
   path: string;
@@ -56,6 +57,7 @@ export function HotDocsPreviewSkeleton() {
  */
 export function HotDocsPreview() {
   const t = useTranslations("hotDocs");
+  const locale = useLocale();
   const [docs, setDocs] = useState<TopDocDto[] | null>(null);
 
   useEffect(() => {
@@ -114,7 +116,7 @@ export function HotDocsPreview() {
               </span>
               <div className="flex-1 min-w-0">
                 <Link
-                  href={doc.path}
+                  href={topDocHref(locale, doc.path)}
                   className="font-serif text-sm font-bold uppercase text-[var(--foreground)] hover:text-[#CC0000] transition-colors leading-tight line-clamp-2 block"
                   data-umami-event="navigation_click"
                   data-umami-event-region="hot_docs_preview"

--- a/app/components/rank/HotDocsTab.tsx
+++ b/app/components/rank/HotDocsTab.tsx
@@ -2,6 +2,8 @@
 
 import { useReducer, useEffect } from "react";
 import Link from "next/link";
+import { useLocale } from "next-intl";
+import { topDocHref } from "@/lib/top-doc-href";
 
 type HotDoc = {
   path: string;
@@ -38,6 +40,7 @@ function reducer(_: State, action: Action): State {
 // 从根拔掉逃生门，同源代理永远成立；想 curl 测后端就直连 api 域名。
 
 export function HotDocsTab({ initialWindow }: { initialWindow: WindowParam }) {
+  const locale = useLocale();
   const [windowParam, setWindowParam] = useReducer(
     (_: WindowParam, next: WindowParam) => next,
     initialWindow,
@@ -165,7 +168,7 @@ export function HotDocsTab({ initialWindow }: { initialWindow: WindowParam }) {
           {state.docs.map((doc, idx) => (
             <Link
               key={doc.path}
-              href={doc.path}
+              href={topDocHref(locale, doc.path)}
               className="group w-full flex items-center gap-4 border border-[var(--foreground)] p-4 bg-[var(--background)] hard-shadow-hover transition-all"
             >
               <div className="font-mono text-2xl font-bold w-12 text-center text-[var(--foreground)] shrink-0">

--- a/lib/top-doc-href.ts
+++ b/lib/top-doc-href.ts
@@ -1,0 +1,11 @@
+/**
+ * top-docs（热门文档榜）后端返回的 path 是无 locale 的 canonical（形如 /docs/learn/ai）。
+ * 拼上当前 locale 前缀得到可点击 URL。
+ *
+ * 防御性归一化：剥掉可能残留的 content/ 前缀和多余前导斜杠，避免后端某次回退到
+ * 旧格式（content/docs/...）时前端直接拼出 /en/content/docs/... 死链。
+ */
+export function topDocHref(locale: string, path: string): string {
+  const clean = "/" + path.replace(/^\/+/, "").replace(/^content\//, "");
+  return `/${locale}${clean}`;
+}


### PR DESCRIPTION
## 问题
`/en/rank?tab=hot` 热门文档榜（及首页"本周最热"）的链接点进去 404，URL 形如 `/en/content/docs/learn/ai`。

## 根因
`HotDocsTab` / `HotDocsPreview` 直接 `<Link href={doc.path}>` 渲染后端返回的 path。后端 top-docs 的 canonical 本应是无 locale 的 `/docs/...`，需前端补当前 locale 前缀；而后端旧 bug 还会泄漏 `content/` 前缀，叠加成 `/en/content/docs/...` 死链。

## 修复
- 新增 `lib/top-doc-href.ts`：`topDocHref(locale, path)` 拼当前 locale 前缀，并**防御性**剥掉可能残留的 `content/` 前缀和多余前导斜杠（后端若回退旧格式也不会再拼出 404）。
- `HotDocsTab`、`HotDocsPreview` 改用 `useLocale()` + `topDocHref`。

> 后端归一化的根因修复在 involutionhell-backend#40（已部署）。本 PR 让链接直达 `/en|zh/docs/...`，省掉一次 next-intl 中间件重定向跳转。

## 验证
- tsc --noEmit 无类型错误。
- 后端修复部署后，37 条 top-docs path × 2 locale 全部 200；本 PR 让前端直接产出 `/{locale}/docs/...`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)