### PR TITLE
fix(auth): header Sign In 跳登录选择页，让用户能选 GitHub / Discord

### DIFF
--- a/app/components/SignInButton.tsx
+++ b/app/components/SignInButton.tsx
@@ -4,21 +4,21 @@ import { Button } from "@/app/components/ui/button";
 
 interface SignInButtonProps {
   className?: string;
-  // 默认 github（header 处无 props 调用不变）；登录页可传 discord。
+  // 传了 provider（登录页两个按钮）→ 直跳该 provider 授权；
+  // 不传（header 的 "Sign In"）→ 跳 /login 让用户在 GitHub / Discord 间选。
   provider?: "github" | "discord";
   label?: string;
 }
 
 export function SignInButton({
   className,
-  provider = "github",
+  provider,
   label = "SignIn",
 }: SignInButtonProps) {
-  // 同源跳到 /oauth/render/{provider}，经 next.config.mjs 的 rewrite 代理到后端。
-  // 好处：开发环境后端端口改来改去都不用改前端；302 由 Next.js 透传给浏览器，
-  // 最终跳到 provider 授权页。各 provider 的 OAuth app 回调 URL 决定返回的前端地址。
+  // provider 已定：同源跳 /oauth/render/{provider}，经 next.config rewrite 代理到后端。
+  // provider 未定：跳 /login 选择页（middleware 会补 locale 前缀）。
   const handleSignIn = () => {
-    window.location.href = `/oauth/render/${provider}`;
+    window.location.href = provider ? `/oauth/render/${provider}` : "/login";
   };
 
   return (
@@ -30,7 +30,7 @@ export function SignInButton({
       data-umami-event="auth_click"
       data-umami-event-action="signin"
       data-umami-event-location="header"
-      data-umami-event-provider={provider}
+      data-umami-event-provider={provider ?? "choose"}
     >
       {label}
     </Button>


### PR DESCRIPTION
## 问题

#382 把 GitHub / Discord 两个登录按钮放在 `/login` 页，但 header 上的 "Sign In"（`AuthNav` 里的 `<SignInButton />`，无 provider）还是**直跳 `/oauth/render/github`**——用户点 header 的 Sign In 就直奔 GitHub 授权，根本看不到 Discord 选项。（登录本身没坏，state cookie 往返实测通过；纯 UX。）

## 改动

`SignInButton`：
- 传 `provider`（登录页两个按钮）→ 直跳 `/oauth/render/{provider}`（不变）
- **不传 provider（header 的 Sign In）→ 跳 `/login` 选择页**，让用户在 GitHub / Discord 间选

header 的 `<SignInButton />` 无 props 调用自动获得"先选后登"，无需改 AuthNav。

typecheck / lint（0 error）通过。