### PR TITLE
fix: resolve docs tree from content root

### DIFF
--- a/app/api/docs-tree/route.ts
+++ b/app/api/docs-tree/route.ts
@@ -89,6 +89,7 @@ async function buildTree(
 export async function GET() {
   const cwd = process.cwd();
   const candidates = [
+    path.join(cwd, "content", "docs"),
     path.join(cwd, "app", "docs"),
     path.join(cwd, "src", "app", "docs"),
   ];


### PR DESCRIPTION
## Summary
Fix the knowledge-base destination picker returning no directories in production.

The docs tree API still searched the pre-i18n paths (`app/docs` and `src/app/docs`), while the current documentation content lives in `content/docs`.

## Validation
- `pnpm typecheck`
- `pnpm lint` (existing warnings only)
- `pnpm test` — 67 tests passed
- Verified `GET /api/docs-tree` locally returns `ok: true` with `content/docs` as `docsRoot`